### PR TITLE
Replaced exit(0) by std::runtime_error

### DIFF
--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -564,9 +564,10 @@ class ArgumentParser {
             // This is a positional argument.
             // Parse and save into mPositionalArguments vector
             if (mNextPositionalArgument >= mPositionalArguments.size()) {
-              std::cout << "error: unexpected positional argument " << argv[i] << std::endl;
+              std::stringstream stream;
+              stream << "error: unexpected positional argument " << argv[i] << std::endl;
               print_help();
-              throw std::runtime_error("unexpected positional argument");
+              throw std::runtime_error(stream.str());
             }
             auto tArgument = mPositionalArguments[mNextPositionalArgument];
             auto tCount = tArgument->mNumArgs - tArgument->mRawValues.size();
@@ -605,11 +606,12 @@ class ArgumentParser {
       // Check if all positional arguments are parsed
       for (const auto& tArgument : mPositionalArguments) {
         if (tArgument->mValues.size() != tArgument->mNumArgs) {
-          std::cout << "error: " << tArgument->mUsedName << ": expected "
+          std::stringstream stream;
+          stream << "error: " << tArgument->mUsedName << ": expected "
             << tArgument->mNumArgs << (tArgument->mNumArgs == 1 ? " argument. " : " arguments. ")
             << tArgument->mValues.size() << " provided.\n" << std::endl;
           print_help();
-          throw std::runtime_error("wrong number of arguments");
+          throw std::runtime_error(stream.str());
         }
       }
 
@@ -620,11 +622,12 @@ class ArgumentParser {
             // All cool if there's a default value to return
             // If no default value, then there's a problem
             if (!tArgument->mDefaultValue.has_value()) {
-              std::cout << "error: " << tArgument->mUsedName << ": expected "
+              std::stringstream stream;
+              stream << "error: " << tArgument->mUsedName << ": expected "
                 << tArgument->mNumArgs << (tArgument->mNumArgs == 1 ? " argument. " : " arguments. ")
                 << tArgument->mValues.size() << " provided.\n" << std::endl;
               print_help();
-              throw std::runtime_error("wrong number of arguments");
+              throw std::runtime_error(stream.str());
             }
           }
         }
@@ -675,6 +678,7 @@ class ArgumentParser {
 try { \
   parser.parse_args(argc, argv); \
 } catch (const std::runtime_error& err) { \
+  std::cerr << err.what() << std::endl; \
   exit(0); \
 }
 

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -77,8 +77,8 @@ public:
     , mIsOptional((is_optional(args) || ...))
   {}
 
-  Argument& help(const std::string& aHelp) {
-    mHelp = aHelp;
+  Argument& help(std::string aHelp) {
+    mHelp = std::move(aHelp);
     return *this;
   }
 

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -671,4 +671,11 @@ class ArgumentParser {
     std::map<std::string, std::shared_ptr<Argument>> mArgumentMap;
 };
 
+#define PARSE_ARGS(parser, argc, argv) \
+try { \
+  parser.parse_args(argc, argv); \
+} catch (const std::runtime_error& err) { \
+  exit(0); \
+}
+
 }

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -483,7 +483,6 @@ class ArgumentParser {
       for (int i = 1; i < argc; i++) {
         auto tCurrentArgument = std::string(argv[i]);
         if (tCurrentArgument == "-h" || tCurrentArgument == "--help") {
-          print_help();
           throw std::runtime_error("help called");
         }
         auto tIterator = mArgumentMap.find(argv[i]);
@@ -566,7 +565,6 @@ class ArgumentParser {
             if (mNextPositionalArgument >= mPositionalArguments.size()) {
               std::stringstream stream;
               stream << "error: unexpected positional argument " << argv[i] << std::endl;
-              print_help();
               throw std::runtime_error(stream.str());
             }
             auto tArgument = mPositionalArguments[mNextPositionalArgument];
@@ -610,7 +608,6 @@ class ArgumentParser {
           stream << "error: " << tArgument->mUsedName << ": expected "
             << tArgument->mNumArgs << (tArgument->mNumArgs == 1 ? " argument. " : " arguments. ")
             << tArgument->mValues.size() << " provided.\n" << std::endl;
-          print_help();
           throw std::runtime_error(stream.str());
         }
       }
@@ -626,7 +623,6 @@ class ArgumentParser {
               stream << "error: " << tArgument->mUsedName << ": expected "
                 << tArgument->mNumArgs << (tArgument->mNumArgs == 1 ? " argument. " : " arguments. ")
                 << tArgument->mValues.size() << " provided.\n" << std::endl;
-              print_help();
               throw std::runtime_error(stream.str());
             }
           }
@@ -679,6 +675,7 @@ try { \
   parser.parse_args(argc, argv); \
 } catch (const std::runtime_error& err) { \
   std::cerr << err.what() << std::endl; \
+  parser.print_help(); \
   exit(0); \
 }
 


### PR DESCRIPTION
On my opinion you should never call `exit` in library code since it is quite difficult for the user to handle this in his application and perform a proper shutdown. Further it is not obvious from your API that the simple parse_args call my exit your whole program.
Further I put your error message into the exceptions to let the application developer decide how the should be logged.