### PR TITLE
Fix warning shown with -Wsign-conversion.

### DIFF
--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -626,7 +626,7 @@ class ArgumentParser {
       std::vector<size_t> argumentLengths(aArguments.size());
       std::transform(std::begin(aArguments), std::end(aArguments), std::begin(argumentLengths), [](const auto& arg) {
         const auto& names = arg->mNames;
-        auto maxLength = std::accumulate(std::begin(names), std::end(names), 0, [](const auto& sum, const auto& s) {
+        auto maxLength = std::accumulate(std::begin(names), std::end(names), std::string::size_type{0}, [](const auto& sum, const auto& s) {
           return sum + s.size() + 2; // +2 for ", "
         });
         return maxLength - 2; // -2 since the last one doesn't need ", "


### PR DESCRIPTION
Fixed a warning I was getting on GCC 8.3.0 with `-Wsign-conversion` enabled.

- Changed `std::accumulate(std::begin(names), std::end(names), 0...` to `std::accumulate(std::begin(names), std::end(names), std::string::size_type{0}...`

I usually find it's best to be explicit with the type you pass to `std::accumulate` as it uses the type it infers as the starting number so it can be a source of pesky bugs.

If you're curious, I use a lot of warning flags when working with code:
```
-Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wmissing-include-dirs -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion -Wsign-promo -Wstrict-overflow=5 -Wundef -Wno-unused
```