### PR TITLE
Allow use of both const char** and char** for argv.

### DIFF
--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -363,7 +363,7 @@ class ArgumentParser {
     /* Main entry point for parsing command-line arguments using this ArgumentParser
      * @throws std::runtime_error in case of any invalid argument
      */
-    void parse_args(int argc, char * argv[]) {
+    void parse_args(int argc, const char * const argv[]) {
       parse_args_internal(argc, argv);
       parse_args_validate();
     }
@@ -481,7 +481,7 @@ class ArgumentParser {
     /*
      * @throws std::runtime_error in case of any invalid argument
      */
-    void parse_args_internal(int argc, char * argv[]) {
+    void parse_args_internal(int argc, const char * const argv[]) {
       if (mProgramName.empty() && argc > 0)
         mProgramName = argv[0];
       for (int i = 1; i < argc; i++) {


### PR DESCRIPTION
Sometimes people use a const qualifier in their definition of main like so:
```cpp
int main(int argc, const char** argv);
```

Currently, the compiler (GCC 8.3.0) with _no extra flags_ will complain about a conversion error from `const char**` -> `char**`.

This PR addresses the problem by allowing _both_ definitions of main so there is no compatibility breaking.