### PR TITLE
Unify Argument::get and Argument::operator== for container types

### DIFF
--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -304,7 +304,7 @@ class ArgumentParser {
       if (tIterator != mArgumentMap.end()) {
         return tIterator->second->get<T>();
       }
-      return T();
+      throw std::logic_error("No such argument");
     }
 
     // Indexing operator. Return a reference to an Argument object
@@ -314,9 +314,7 @@ class ArgumentParser {
       if (tIterator != mArgumentMap.end()) {
         return *(tIterator->second);
       }
-      else {
-        throw std::runtime_error("Argument " + aArgumentName + " not found");
-      }
+      throw std::logic_error("No such argument");
     }
 
     // Printing the one and only help message
@@ -390,12 +388,6 @@ class ArgumentParser {
     }
 
   private:
-    // If the argument was defined by the user and can be found in mArgumentMap, then it's valid
-    bool is_valid_argument(const std::string& aName) {
-      auto tIterator = mArgumentMap.find(aName);
-      return (tIterator != mArgumentMap.end());
-    }
-
     /*
      * @throws std::runtime_error in case of any invalid argument
      */

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -152,14 +152,20 @@ public:
     return !(*this == aRhs);
   }
 
-  // Entry point for template types other than std::vector and std::list
+  /*
+   * Entry point for template non-container types
+   * @throws std::logic_error in case of incompatible types
+   */
   template <typename T>
   std::enable_if_t <!is_container_v<T>, bool>
   operator==(const T& aRhs) const {
     return get<T>() == aRhs;
   }
 
-  // Template specialization for containers
+  /*
+   * Template specialization for containers
+   * @throws std::logic_error in case of incompatible types
+   */
   template <typename T>
   std::enable_if_t <is_container_v<T>, bool>
   operator==(const T& aRhs) const {
@@ -180,7 +186,10 @@ public:
       return (starts_with(aName, "--") || starts_with(aName, "-"));
     }
 
-    // Getter for template types other than std::vector and std::list
+    /*
+     * Getter for template non-container types
+     * @throws std::logic_error in case of incompatible types
+     */
     template <typename T>
     enable_if_not_container<T>
     get() const {
@@ -193,7 +202,10 @@ public:
       throw std::logic_error("No value provided");
     }
 
-    // Getter for container types
+    /*
+     * Getter for container types
+     * @throws std::logic_error in case of incompatible types
+     */
     template <typename CONTAINER>
     enable_if_container<CONTAINER>
     get() const {
@@ -297,7 +309,10 @@ class ArgumentParser {
       parse_args_validate();
     }
 
-    // Getter enabled for all template types other than std::vector and std::list
+    /* Getter enabled for all template types other than std::vector and std::list
+     * @throws std::logic_error in case of an invalid argument name
+     * @throws std::logic_error in case of incompatible types
+     */
     template <typename T = std::string>
     T get(const std::string& aArgumentName) {
       auto tIterator = mArgumentMap.find(aArgumentName);
@@ -307,8 +322,10 @@ class ArgumentParser {
       throw std::logic_error("No such argument");
     }
 
-    // Indexing operator. Return a reference to an Argument object
-    // Used in conjuction with Argument.operator== e.g., parser["foo"] == true
+    /* Indexing operator. Return a reference to an Argument object
+     * Used in conjuction with Argument.operator== e.g., parser["foo"] == true
+     * @throws std::logic_error in case of an invalid argument name
+     */
     Argument& operator[](const std::string& aArgumentName) {
       auto tIterator = mArgumentMap.find(aArgumentName);
       if (tIterator != mArgumentMap.end()) {

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -45,12 +45,6 @@ SOFTWARE.
 namespace argparse {
 
 namespace { // anonymous namespace for helper methods - not visible outside this header file
-// Some utility structs to check template specialization
-template<typename Test, template<typename...> class Ref>
-struct is_specialization : std::false_type {};
-
-template<template<typename...> class Ref, typename... Args>
-struct is_specialization<Ref<Args...>, Ref> : std::true_type {};
 
 template<typename... Ts>
 struct is_container_helper {};

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -58,6 +58,9 @@ struct is_container_helper {};
 template<typename T, typename _ = void>
 struct is_container : std::false_type {};
 
+template<>
+struct is_container<std::string> : std::false_type {};
+
 template<typename T>
 struct is_container<T, std::conditional_t<
     false, is_container_helper<

--- a/test/test_compound_arguments.hpp
+++ b/test/test_compound_arguments.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <catch.hpp>
 #include <argparse.hpp>
+#include <test_utility.hpp>
 
 TEST_CASE("Parse compound toggle arguments with implicit values", "[compound_arguments]") {
   argparse::ArgumentParser program("test");
@@ -97,9 +98,9 @@ TEST_CASE("Parse compound toggle arguments with implicit values and nargs and ot
   REQUIRE(numbers[2] == 3);
   auto numbers_list = program.get<std::list<int>>("numbers");
   REQUIRE(numbers.size() == 3);
-  REQUIRE(argparse::get_from_list(numbers_list, 0) == 1);
-  REQUIRE(argparse::get_from_list(numbers_list, 1) == 2);
-  REQUIRE(argparse::get_from_list(numbers_list, 2) == 3);
+  REQUIRE(testutility::get_from_list(numbers_list, 0) == 1);
+  REQUIRE(testutility::get_from_list(numbers_list, 1) == 2);
+  REQUIRE(testutility::get_from_list(numbers_list, 2) == 3);
 }
 
 TEST_CASE("Parse out-of-order compound arguments", "[compound_arguments]") {

--- a/test/test_container_arguments.hpp
+++ b/test/test_container_arguments.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <catch.hpp>
 #include <argparse.hpp>
+#include <test_utility.hpp>
 
 TEST_CASE("Parse vector of arguments", "[vector]") {
   argparse::ArgumentParser program("test");
@@ -24,8 +25,8 @@ TEST_CASE("Parse list of arguments", "[vector]") {
 
   auto inputs = program.get<std::list<std::string>>("input");
   REQUIRE(inputs.size() == 2);
-  REQUIRE(argparse::get_from_list(inputs, 0) == "rocket.mesh");
-  REQUIRE(argparse::get_from_list(inputs, 1) == "thrust_profile.csv");
+  REQUIRE(testutility::get_from_list(inputs, 0) == "rocket.mesh");
+  REQUIRE(testutility::get_from_list(inputs, 1) == "thrust_profile.csv");
 }
 
 TEST_CASE("Parse list of arguments with default values", "[vector]") {
@@ -38,11 +39,11 @@ TEST_CASE("Parse list of arguments with default values", "[vector]") {
 
   auto inputs = program.get<std::list<int>>("--input");
   REQUIRE(inputs.size() == 5);
-  REQUIRE(argparse::get_from_list(inputs, 0) == 1);
-  REQUIRE(argparse::get_from_list(inputs, 1) == 2);
-  REQUIRE(argparse::get_from_list(inputs, 2) == 3);
-  REQUIRE(argparse::get_from_list(inputs, 3) == 4);
-  REQUIRE(argparse::get_from_list(inputs, 4) == 5);
+  REQUIRE(testutility::get_from_list(inputs, 0) == 1);
+  REQUIRE(testutility::get_from_list(inputs, 1) == 2);
+  REQUIRE(testutility::get_from_list(inputs, 2) == 3);
+  REQUIRE(testutility::get_from_list(inputs, 3) == 4);
+  REQUIRE(testutility::get_from_list(inputs, 4) == 5);
   REQUIRE(program["--input"] == std::list<int>{1, 2, 3, 4, 5});
 }
 

--- a/test/test_utility.hpp
+++ b/test/test_utility.hpp
@@ -1,0 +1,17 @@
+#ifndef ARGPARSE_TEST_UTILITY_HPP
+#define ARGPARSE_TEST_UTILITY_HPP
+
+namespace testutility {
+// Get value at index from std::list
+template <typename T>
+T get_from_list(const std::list<T>& aList, size_t aIndex) {
+  if (aList.size() > aIndex) {
+    auto tIterator = aList.begin();
+    std::advance(tIterator, aIndex);
+    return *tIterator;
+  }
+  return T();
+}
+}
+
+#endif //ARGPARSE_TEST_UTILITY_HPP


### PR DESCRIPTION
- Use a single function for container types for
  - Argument::get
  - Argument::operator==
- throw std::logic_error instead of returning default value in Argument::get
