### PR TITLE
Simplify structure of parse_args_internal

### DIFF
--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -462,10 +462,13 @@ class ArgumentParser {
               auto tArgument = tIterator->second;
               it = tArgument->consume(it, end, tCurrentArgument);
             }
+            else {
+              throw std::runtime_error("Unknown argument");
+            }
           }
         }
         else {
-          ++it;
+          throw std::runtime_error("Unknown argument");
         }
       }
     }

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -436,16 +436,17 @@ class ArgumentParser {
         mProgramName = aArguments.front();
       }
       auto end = std::end(aArguments);
+      auto positionalArgumentIt = std::begin(mPositionalArguments);
       for (auto it = std::next(std::begin(aArguments)); it != end;) {
         const auto& tCurrentArgument = *it;
         if (tCurrentArgument == Argument::mHelpOption || tCurrentArgument == Argument::mHelpOptionLong) {
           throw std::runtime_error("help called");
         }
         if (Argument::is_positional(tCurrentArgument)) {
-          if (mNextPositionalArgument >= mPositionalArguments.size()) {
+          if (positionalArgumentIt == std::end(mPositionalArguments)) {
             throw std::runtime_error("Maximum number of positional arguments exceeded");
           }
-          auto tArgument = mPositionalArguments[mNextPositionalArgument++];
+          auto tArgument = *(positionalArgumentIt++);
           it = tArgument->consume(it, end);
         }
         else if (auto tIterator = mArgumentMap.find(tCurrentArgument); tIterator != mArgumentMap.end()) {
@@ -505,7 +506,6 @@ class ArgumentParser {
     std::vector<ArgumentParser> mParentParsers;
     std::vector<std::shared_ptr<Argument>> mPositionalArguments;
     std::vector<std::shared_ptr<Argument>> mOptionalArguments;
-    size_t mNextPositionalArgument = 0;
     std::map<std::string, std::shared_ptr<Argument>> mArgumentMap;
 };
 

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -73,12 +73,6 @@ using enable_if_container = std::enable_if_t<is_container_v<T>, T>;
 
 template <typename T>
 using enable_if_not_container = std::enable_if_t<!is_container_v<T>, T>;
-
-// Check if string (haystack) starts with a substring (needle)
-bool starts_with(const std::string& haystack, const std::string& needle) {
-  return needle.length() <= haystack.length()
-    && std::equal(needle.begin(), needle.end(), haystack.begin());
-}
 }
 
 class Argument {
@@ -180,7 +174,7 @@ public:
   private:
     // If an argument starts with "-" or "--", then it's optional
     static bool is_optional(const std::string& aName) {
-      return (starts_with(aName, "--") || starts_with(aName, "-"));
+      return (!aName.empty() && aName[0] == '-');
     }
 
     /*

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -451,7 +451,20 @@ class ArgumentParser {
             auto tArgument = tIterator->second;
             it = tArgument->consume(std::next(it), end, tCurrentArgument);
         }
-        else { // TODO: compound optional arguments
+        else if (const auto& tCompoundArgument = tCurrentArgument;
+                 tCompoundArgument.size() > 1 &&
+                 tCompoundArgument[0] == '-'  &&
+                 tCompoundArgument[1] != '-') {
+          ++it;
+          for (size_t j = 1; j < tCompoundArgument.size(); j++) {
+            auto tCurrentArgument = std::string{'-', tCompoundArgument[j]};
+            if (auto tIterator = mArgumentMap.find(tCurrentArgument); tIterator != mArgumentMap.end()) {
+              auto tArgument = tIterator->second;
+              it = tArgument->consume(it, end, tCurrentArgument);
+            }
+          }
+        }
+        else {
           ++it;
         }
       }

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -204,6 +204,10 @@ public:
       return (!aName.empty() && aName[0] == '-');
     }
 
+    static bool is_positional(const std::string& aName) {
+      return !is_optional(aName);
+    }
+
     /*
      * Getter for template non-container types
      * @throws std::logic_error in case of incompatible types
@@ -436,17 +440,16 @@ class ArgumentParser {
         if (tCurrentArgument == Argument::mHelpOption || tCurrentArgument == Argument::mHelpOptionLong) {
           throw std::runtime_error("help called");
         }
-        auto tIterator = mArgumentMap.find(tCurrentArgument);
-        if (tIterator != mArgumentMap.end()) {
-          auto tArgument = tIterator->second;
-          it = tArgument->consume(std::next(it), end, tCurrentArgument);
-        }
-        else if (!Argument::is_optional(tCurrentArgument)) {
+        if (Argument::is_positional(tCurrentArgument)) {
           if (mNextPositionalArgument >= mPositionalArguments.size()) {
             throw std::runtime_error("Maximum number of positional arguments exceeded");
           }
           auto tArgument = mPositionalArguments[mNextPositionalArgument++];
           it = tArgument->consume(it, end);
+        }
+        else if (auto tIterator = mArgumentMap.find(tCurrentArgument); tIterator != mArgumentMap.end()) {
+            auto tArgument = tIterator->second;
+            it = tArgument->consume(std::next(it), end, tCurrentArgument);
         }
         else { // TODO: compound optional arguments
           ++it;

--- a/test/test_compound_arguments.hpp
+++ b/test/test_compound_arguments.hpp
@@ -77,30 +77,7 @@ TEST_CASE("Parse compound toggle arguments with implicit values and nargs and ot
   program.add_argument("--input_files")
     .nargs(3);
 
-  program.parse_args({ "./test.exe", "1", "-abc", "3.14", "2.718", "2", "--input_files",
-    "a.txt", "b.txt", "c.txt", "3" });
-
-  REQUIRE(program.get<bool>("-a") == true);
-  REQUIRE(program.get<bool>("-b") == true);
-  auto c = program.get<std::vector<float>>("-c");
-  REQUIRE(c.size() == 2);
-  REQUIRE(c[0] == 3.14f);
-  REQUIRE(c[1] == 2.718f);
-  auto input_files = program.get<std::vector<std::string>>("--input_files");
-  REQUIRE(input_files.size() == 3);
-  REQUIRE(input_files[0] == "a.txt");
-  REQUIRE(input_files[1] == "b.txt");
-  REQUIRE(input_files[2] == "c.txt");
-  auto numbers = program.get<std::vector<int>>("numbers");
-  REQUIRE(numbers.size() == 3);
-  REQUIRE(numbers[0] == 1);
-  REQUIRE(numbers[1] == 2);
-  REQUIRE(numbers[2] == 3);
-  auto numbers_list = program.get<std::list<int>>("numbers");
-  REQUIRE(numbers.size() == 3);
-  REQUIRE(testutility::get_from_list(numbers_list, 0) == 1);
-  REQUIRE(testutility::get_from_list(numbers_list, 1) == 2);
-  REQUIRE(testutility::get_from_list(numbers_list, 2) == 3);
+  REQUIRE_THROWS(program.parse_args({ "./test.exe", "1", "-abc", "3.14", "2.718", "2", "--input_files", "a.txt", "b.txt", "c.txt", "3" }));
 }
 
 TEST_CASE("Parse out-of-order compound arguments", "[compound_arguments]") {

--- a/test/test_invalid_arguments.hpp
+++ b/test/test_invalid_arguments.hpp
@@ -34,5 +34,5 @@ TEST_CASE("Parse unknown optional argument", "[compound_arguments]") {
     .action([](const std::string& val) { return std::stoull(val); })
     .help("memory in MB to give the VMM when loading");
 
-  bfm.parse_args({ "./test.exe", "-om" });
+  REQUIRE_THROWS(bfm.parse_args({ "./test.exe", "-om" }));
 }

--- a/test/test_positional_arguments.hpp
+++ b/test/test_positional_arguments.hpp
@@ -44,13 +44,7 @@ TEST_CASE("Parse positional arguments with optional arguments in the middle", "[
   program.add_argument("output").nargs(2);
   program.add_argument("--num_iterations")
     .action([](const std::string& value) { return std::stoi(value); });
-  program.parse_args({ "test", "rocket.mesh", "thrust_profile.csv", "--num_iterations", "15", "output.mesh" });
-  REQUIRE(program.get<int>("--num_iterations") == 15);
-  REQUIRE(program.get("input") == "rocket.mesh");
-  auto outputs = program.get<std::vector<std::string>>("output");
-  REQUIRE(outputs.size() == 2);
-  REQUIRE(outputs[0] == "thrust_profile.csv");
-  REQUIRE(outputs[1] == "output.mesh");
+  REQUIRE_THROWS(program.parse_args({ "test", "rocket.mesh", "thrust_profile.csv", "--num_iterations", "15", "output.mesh" }));
 }
 
 TEST_CASE("Square a number", "[positional_arguments]") {


### PR DESCRIPTION
Simplified structure of arg parsing using stl algorithms to improve readability, maintainability and extendability.
The only drawback is that optional arguments may no longer occur in between arguments belonging to the same positional argument (compare changed tests). But on my oppinion this should not really be a use case. 