### PR TITLE
Fix invalid cmake export configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(argparse::argparse ALIAS argparse)
 target_compile_features(argparse INTERFACE cxx_std_17)
 target_include_directories(argparse INTERFACE
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>/include)
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
 
 if(ARGPARSE_BUILD_TESTS)
   add_subdirectory(test)


### PR DESCRIPTION
Modify the CMakeLists.txt file to properly generate config file.
The `/include` string part intended for BUILD_INTERFACE was added
after the generator expression itself, which resulted
in extra `/include` path INTERFACE_INCLUDE_DIRECTORIES property
of exported configuration.