### PR TITLE
Allow actions that return void

### DIFF
--- a/test/test_actions.hpp
+++ b/test/test_actions.hpp
@@ -2,7 +2,7 @@
 #include <catch.hpp>
 #include <argparse.hpp>
 
-TEST_CASE("Users can use defaul value inside actions", "[actions]") {
+TEST_CASE("Users can use default value inside actions", "[actions]") {
   argparse::ArgumentParser program("test");
   program.add_argument("input")
     .default_value("bar")
@@ -16,4 +16,26 @@ TEST_CASE("Users can use defaul value inside actions", "[actions]") {
 
   program.parse_args({ "test", "fez" });
   REQUIRE(program.get("input") == "bar");
+}
+
+TEST_CASE("Users can add actions that return nothing", "[actions]") {
+  argparse::ArgumentParser program("test");
+  bool pressed = false;
+  auto &arg = program.add_argument("button").action(
+      [&](const std::string &) mutable { pressed = true; });
+
+  REQUIRE_FALSE(pressed);
+
+  SECTION("action performed") {
+    program.parse_args({"test", "ignored"});
+    REQUIRE(pressed);
+  }
+
+  SECTION("action performed and nothing overrides the default value") {
+    arg.default_value(42);
+
+    program.parse_args({"test", "ignored"});
+    REQUIRE(pressed);
+    REQUIRE(program.get<int>("button") == 42);
+  }
 }


### PR DESCRIPTION
Hi,

I'm not sure about how side-effects-only actions should interact with default values etc.  I'm trying to not let it overrides default values.  Code owner please check.

closes: p-ranav/argparse#39