### PR TITLE
Bind in action

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -90,10 +90,12 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
-RawStringFormats: 
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    google
+RawStringFormats:
+  - Language: TextProto
+    Delimiters:
+      - 'pb'
+      - 'proto'
+    BasedOnStyle: google
 ReflowComments:  true
 SortIncludes:    true
 SortUsingDeclarations: true

--- a/test/test_actions.hpp
+++ b/test/test_actions.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <catch.hpp>
 #include <argparse.hpp>
+#include <string_view>
 
 TEST_CASE("Users can use default value inside actions", "[actions]") {
   argparse::ArgumentParser program("test");
@@ -37,5 +38,84 @@ TEST_CASE("Users can add actions that return nothing", "[actions]") {
     program.parse_args({"test", "ignored"});
     REQUIRE(pressed);
     REQUIRE(program.get<int>("button") == 42);
+  }
+}
+
+class Image {
+public:
+  int w = 0, h = 0;
+
+  void resize(std::string_view geometry) {
+    std::stringstream s;
+    s << geometry;
+    s >> w;
+    s.ignore();
+    s >> h;
+  }
+
+  static auto create(int w, int h, std::string_view format) -> Image {
+    auto factor = [=] {
+      if (format == "720p")
+        return std::min(1280. / w, 720. / h);
+      else if (format == "1080p")
+        return std::min(1920. / w, 1080. / h);
+      else
+        return 1.;
+    }();
+
+    return {static_cast<int>(w * factor), static_cast<int>(h * factor)};
+  }
+};
+
+TEST_CASE("Users can bind arguments to actions", "[actions]") {
+  argparse::ArgumentParser program("test");
+
+  GIVEN("an default initialized object bounded by reference") {
+    Image img;
+    program.add_argument("--size").action(&Image::resize, std::ref(img));
+
+    WHEN("provided no command-line arguments") {
+      program.parse_args({"test"});
+
+      THEN("the object is not updated") {
+        REQUIRE(img.w == 0);
+        REQUIRE(img.h == 0);
+      }
+    }
+
+    WHEN("provided command-line arguments") {
+      program.parse_args({"test", "--size", "320x98"});
+
+      THEN("the object is updated accordingly") {
+        REQUIRE(img.w == 320);
+        REQUIRE(img.h == 98);
+      }
+    }
+  }
+
+  GIVEN("a command-line option waiting for the last argument in its action") {
+    program.add_argument("format").action(Image::create, 400, 300);
+
+    WHEN("provided such an argument") {
+      program.parse_args({"test", "720p"});
+
+      THEN("the option object is created as if providing all arguments") {
+        auto img = program.get<Image>("format");
+
+        REQUIRE(img.w == 960);
+        REQUIRE(img.h == 720);
+      }
+    }
+
+    WHEN("provided a different argument") {
+      program.parse_args({"test", "1080p"});
+
+      THEN("a different option object is created") {
+        auto img = program.get<Image>("format");
+
+        REQUIRE(img.w == 1440);
+        REQUIRE(img.h == 1080);
+      }
+    }
   }
 }


### PR DESCRIPTION
The semantics I chose here is slightly different from `std::bind_front` but is as same as `std::bind` (with a much simpler codegen though) -- the bounded arguments unwrap `std::reference_wrapper`.  Long story short, I think the rationale in http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1651r0.html doesn't apply to our case, because the intermediate partial-application objects do not escape argparse.

When binding member calls, `.action(&Class::fn, std::ref(obj))` and `.action(&Class::fn, &obj)` both work.  Pedantic people may not like the later because `operator&` may be overloaded.

It would be fun to use one example to demo both void-actions and partial applications.

closes: p-ranav/argparse#38