### PR TITLE
Finishing cleanup by refactoring SFINAE into constexpr-if

### DIFF
--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -341,17 +341,23 @@ private:
   template <typename CONTAINER>
   details::enable_if_container<CONTAINER> get() const {
     if (!mValues.empty()) {
-      using ValueType = typename CONTAINER::value_type;
-      CONTAINER tResult;
-      std::transform(
-          std::begin(mValues), std::end(mValues), std::back_inserter(tResult),
-          [](const auto &value) { return std::any_cast<ValueType>(value); });
-      return tResult;
+      return any_cast_container<CONTAINER>(mValues);
     }
     if (mDefaultValue.has_value()) {
       return std::any_cast<CONTAINER>(mDefaultValue);
     }
     throw std::logic_error("No value provided");
+  }
+
+  template <typename T>
+  static auto any_cast_container(const std::vector<std::any> &aOperand) -> T {
+    using ValueType = typename T::value_type;
+
+    T tResult;
+    std::transform(
+        begin(aOperand), end(aOperand), std::back_inserter(tResult),
+        [](const auto &value) { return std::any_cast<ValueType>(value); });
+    return tResult;
   }
 
   std::vector<std::string> mNames;

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -561,11 +561,11 @@ private:
                  tCompoundArgument[1] != '-') {
         ++it;
         for (size_t j = 1; j < tCompoundArgument.size(); j++) {
-          auto tCurrentArgument = std::string{'-', tCompoundArgument[j]};
-          if (auto tIterator = mArgumentMap.find(tCurrentArgument);
-              tIterator != mArgumentMap.end()) {
-            auto tArgument = tIterator->second;
-            it = tArgument->consume(it, end, tCurrentArgument);
+          auto tHypotheticalArgument = std::string{'-', tCompoundArgument[j]};
+          auto tIterator2 = mArgumentMap.find(tHypotheticalArgument);
+          if (tIterator2 != mArgumentMap.end()) {
+            auto tArgument = tIterator2->second;
+            it = tArgument->consume(it, end, tHypotheticalArgument);
           } else {
             throw std::runtime_error("Unknown argument");
           }

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -340,22 +340,16 @@ private:
    */
   template <typename CONTAINER>
   details::enable_if_container<CONTAINER> get() const {
-    using ValueType = typename CONTAINER::value_type;
-    CONTAINER tResult;
     if (!mValues.empty()) {
+      using ValueType = typename CONTAINER::value_type;
+      CONTAINER tResult;
       std::transform(
           std::begin(mValues), std::end(mValues), std::back_inserter(tResult),
           [](const auto &value) { return std::any_cast<ValueType>(value); });
       return tResult;
     }
     if (mDefaultValue.has_value()) {
-      const auto &tDefaultValues =
-          std::any_cast<const CONTAINER &>(mDefaultValue);
-      std::transform(std::begin(tDefaultValues), std::end(tDefaultValues),
-                     std::back_inserter(tResult), [](const auto &value) {
-                       return std::any_cast<ValueType>(value);
-                     });
-      return tResult;
+      return std::any_cast<CONTAINER>(mDefaultValue);
     }
     throw std::logic_error("No value provided");
   }

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -70,6 +70,11 @@ template <typename T>
 static constexpr bool is_container_v = is_container<T>::value;
 
 template <typename T>
+struct is_string_like
+    : std::conjunction<std::is_constructible<std::string, T>,
+                       std::is_convertible<T, std::string_view>> {};
+
+template <typename T>
 using enable_if_container = std::enable_if_t<is_container_v<T>, T>;
 
 template <typename T>
@@ -115,8 +120,7 @@ public:
 
   template <typename... Args,
             std::enable_if_t<
-                std::conjunction_v<std::is_constructible<std::string, Args>...>,
-                int> = 0>
+                std::conjunction_v<details::is_string_like<Args>...>, int> = 0>
   explicit Argument(Args &&... args)
       : Argument({std::string(std::forward<Args>(args))...},
                  std::make_index_sequence<sizeof...(Args)>{}) {}


### PR DESCRIPTION
SFINAE is only useful as constraints.  A overload set that works for all `T`, no matter `Predicate<T>` is true or false, is effectively unconstrained.  Constexpr if statements work better in that case.

This change also eliminates the last two warnings in MSVC, surpressed a stupid Codacy warning, and fixed a two minor issues (redundant any, missed constraint).