### PR TITLE
Support capturing remaining() arguments

### DIFF
--- a/test/test_actions.hpp
+++ b/test/test_actions.hpp
@@ -119,3 +119,15 @@ TEST_CASE("Users can bind arguments to actions", "[actions]") {
     }
   }
 }
+
+TEST_CASE("Users can use actions on remaining arguments", "[actions]") {
+  argparse::ArgumentParser program("sum");
+
+  int result = 0;
+  program.add_argument("all").remaining().action(
+      [](int &sum, std::string const &value) { sum += std::stoi(value); },
+      std::ref(result));
+
+  program.parse_args({"sum", "42", "100", "-3", "-20"});
+  REQUIRE(result == 119);
+}

--- a/test/test_optional_arguments.hpp
+++ b/test/test_optional_arguments.hpp
@@ -45,6 +45,35 @@ TEST_CASE("Parse multiple toggle arguments with implicit values", "[optional_arg
   REQUIRE(program.get<bool>("-x") == true);
 }
 
+TEST_CASE("Parse optional arguments of many values", "[optional_arguments]") {
+  GIVEN("a program that accepts an optional argument of many values") {
+    argparse::ArgumentParser program("test");
+    program.add_argument("-i").remaining().action(
+        [](const std::string &value) { return std::stoi(value); });
+
+    WHEN("provided no argument") {
+      THEN("the program accepts it but gets nothing") {
+        REQUIRE_NOTHROW(program.parse_args({"test"}));
+        REQUIRE_THROWS_AS(program.get<std::vector<int>>("-i"),
+                          std::logic_error);
+      }
+    }
+
+    WHEN("provided remaining arguments follow the option") {
+      program.parse_args({"test", "-i", "-42", "8", "100", "300"});
+
+      THEN("the optional parameter consumes all of them") {
+        auto inputs = program.get<std::vector<int>>("-i");
+        REQUIRE(inputs.size() == 4);
+        REQUIRE(inputs[0] == -42);
+        REQUIRE(inputs[1] == 8);
+        REQUIRE(inputs[2] == 100);
+        REQUIRE(inputs[3] == 300);
+      }
+    }
+  }
+}
+
 TEST_CASE("Parse arguments of different types", "[optional_arguments]") {
   using namespace std::literals;
 

--- a/test/test_positional_arguments.hpp
+++ b/test/test_positional_arguments.hpp
@@ -47,6 +47,59 @@ TEST_CASE("Parse positional arguments with optional arguments in the middle", "[
   REQUIRE_THROWS(program.parse_args({ "test", "rocket.mesh", "thrust_profile.csv", "--num_iterations", "15", "output.mesh" }));
 }
 
+TEST_CASE("Parse remaining arguments deemed positional",
+          "[positional_arguments]") {
+  GIVEN("a program that accepts an optional argument and remaining arguments") {
+    argparse::ArgumentParser program("test");
+    program.add_argument("-o");
+    program.add_argument("input").remaining();
+
+    WHEN("provided no argument") {
+      THEN("the program accepts it but gets nothing") {
+        REQUIRE_NOTHROW(program.parse_args({"test"}));
+        REQUIRE_THROWS_AS(program.get<std::vector<std::string>>("input"),
+                          std::logic_error);
+      }
+    }
+
+    WHEN("provided an optional followed by remaining arguments") {
+      program.parse_args({"test", "-o", "a.out", "a.c", "b.c", "main.c"});
+
+      THEN("the optional parameter consumes an argument") {
+        using namespace std::literals;
+        REQUIRE(program["-o"] == "a.out"s);
+
+        auto inputs = program.get<std::vector<std::string>>("input");
+        REQUIRE(inputs.size() == 3);
+        REQUIRE(inputs[0] == "a.c");
+        REQUIRE(inputs[1] == "b.c");
+        REQUIRE(inputs[2] == "main.c");
+      }
+    }
+
+    WHEN("provided remaining arguments including optional arguments") {
+      program.parse_args({"test", "a.c", "b.c", "main.c", "-o", "a.out"});
+
+      THEN("the optional argument is deemed remaining") {
+        REQUIRE_THROWS_AS(program.get("-o"), std::logic_error);
+
+        auto inputs = program.get<std::vector<std::string>>("input");
+        REQUIRE(inputs.size() == 5);
+        REQUIRE(inputs[0] == "a.c");
+        REQUIRE(inputs[1] == "b.c");
+        REQUIRE(inputs[2] == "main.c");
+        REQUIRE(inputs[3] == "-o");
+        REQUIRE(inputs[4] == "a.out");
+      }
+    }
+  }
+}
+
+TEST_CASE("Negative nargs is not allowed", "[positional_arguments]") {
+  argparse::ArgumentParser program("test");
+  REQUIRE_THROWS_AS(program.add_argument("output").nargs(-1), std::logic_error);
+}
+
 TEST_CASE("Square a number", "[positional_arguments]") {
   argparse::ArgumentParser program;
   program.add_argument("--verbose", "-v")


### PR DESCRIPTION
This kind of argument works as if having the "remaining" nargs,
inspired by Python's `argparse.REMAINDER`.

This change also reduces the size of `Argument` by 8 bytes.

See also: https://docs.python.org/2/library/argparse.html#nargs

PS1: document is missing, but in the unit test there is a test case "sum" for helping forming an official example.
PS2: after resolving #56, I think that's enough features for the next release.  Thoughts?

fixes: p-ranav/argparse#17