### PR TITLE
Annotate test cases with doctest::test_suite

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,8 +24,24 @@ endif()
 
 # ARGPARSE executable
 file(GLOB ARGPARSE_TEST_SOURCES
-    "*.cpp"
+    main.cpp
+    test_actions.cpp
+    test_compound_arguments.cpp
+    test_container_arguments.cpp
+    test_help.cpp
+    test_invalid_arguments.cpp
+    test_issue_37.cpp
+    test_negative_numbers.cpp
+    test_optional_arguments.cpp
+    test_parent_parsers.cpp
+    test_parse_args.cpp
+    test_positional_arguments.cpp
+    test_required_arguments.cpp
+    test_value_semantics.cpp
 )
+set_source_files_properties(main.cpp
+    PROPERTIES
+    COMPILE_DEFINITIONS DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN)
 ADD_EXECUTABLE(ARGPARSE ${ARGPARSE_TEST_SOURCES})
 INCLUDE_DIRECTORIES("../include" ".")
 set_target_properties(ARGPARSE PROPERTIES OUTPUT_NAME tests)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,2 +1,1 @@
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest.hpp>

--- a/test/test_actions.cpp
+++ b/test/test_actions.cpp
@@ -1,8 +1,10 @@
 #include <doctest.hpp>
 #include <argparse.hpp>
-#include <string_view>
 
-DOCTEST_TEST_CASE("Users can use default value inside actions [actions]") {
+using doctest::test_suite;
+
+TEST_CASE("Users can use default value inside actions" *
+          test_suite("actions")) {
   argparse::ArgumentParser program("test");
   program.add_argument("input")
     .default_value("bar")
@@ -18,7 +20,7 @@ DOCTEST_TEST_CASE("Users can use default value inside actions [actions]") {
   REQUIRE(program.get("input") == "bar");
 }
 
-DOCTEST_TEST_CASE("Users can add actions that return nothing [actions]") {
+TEST_CASE("Users can add actions that return nothing" * test_suite("actions")) {
   argparse::ArgumentParser program("test");
   bool pressed = false;
   auto &arg = program.add_argument("button").action(
@@ -26,12 +28,12 @@ DOCTEST_TEST_CASE("Users can add actions that return nothing [actions]") {
 
   REQUIRE_FALSE(pressed);
 
-  DOCTEST_SUBCASE("action performed") {
+  SUBCASE("action performed") {
     program.parse_args({"test", "ignored"});
     REQUIRE(pressed);
   }
 
-  DOCTEST_SUBCASE("action performed and nothing overrides the default value") {
+  SUBCASE("action performed and nothing overrides the default value") {
     arg.default_value(42);
 
     program.parse_args({"test", "ignored"});
@@ -66,7 +68,7 @@ public:
   }
 };
 
-DOCTEST_TEST_CASE("Users can bind arguments to actions [actions]") {
+TEST_CASE("Users can bind arguments to actions" * test_suite("actions")) {
   argparse::ArgumentParser program("test");
 
   GIVEN("an default initialized object bounded by reference") {
@@ -119,7 +121,8 @@ DOCTEST_TEST_CASE("Users can bind arguments to actions [actions]") {
   }
 }
 
-DOCTEST_TEST_CASE("Users can use actions on remaining arguments [actions]") {
+TEST_CASE("Users can use actions on remaining arguments" *
+          test_suite("actions")) {
   argparse::ArgumentParser program("sum");
 
   int result = 0;

--- a/test/test_compound_arguments.cpp
+++ b/test/test_compound_arguments.cpp
@@ -2,7 +2,10 @@
 #include <argparse.hpp>
 #include <test_utility.hpp>
 
-DOCTEST_TEST_CASE("Parse compound toggle arguments with implicit values [compound_arguments]") {
+using doctest::test_suite;
+
+TEST_CASE("Parse compound toggle arguments with implicit values" *
+          test_suite("compound_arguments")) {
   argparse::ArgumentParser program("test");
   program.add_argument("-a")
     .default_value(false)
@@ -22,7 +25,8 @@ DOCTEST_TEST_CASE("Parse compound toggle arguments with implicit values [compoun
   REQUIRE(program.get<bool>("-x") == true);
 }
 
-DOCTEST_TEST_CASE("Parse compound toggle arguments with implicit values and nargs [compound_arguments]") {
+TEST_CASE("Parse compound toggle arguments with implicit values and nargs" *
+          test_suite("compound_arguments")) {
   argparse::ArgumentParser program("test");
   program.add_argument("-a")
     .default_value(false)
@@ -54,7 +58,9 @@ DOCTEST_TEST_CASE("Parse compound toggle arguments with implicit values and narg
   REQUIRE(input_files[2] == "c.txt");
 }
 
-DOCTEST_TEST_CASE("Parse compound toggle arguments with implicit values and nargs and other positional arguments [compound_arguments]") {
+TEST_CASE("Parse compound toggle arguments with implicit values and nargs and "
+          "other positional arguments" *
+          test_suite("compound_arguments")) {
   argparse::ArgumentParser program("test");
 
   program.add_argument("numbers")
@@ -79,7 +85,8 @@ DOCTEST_TEST_CASE("Parse compound toggle arguments with implicit values and narg
   REQUIRE_THROWS(program.parse_args({ "./test.exe", "1", "-abc", "3.14", "2.718", "2", "--input_files", "a.txt", "b.txt", "c.txt", "3" }));
 }
 
-DOCTEST_TEST_CASE("Parse out-of-order compound arguments [compound_arguments]") {
+TEST_CASE("Parse out-of-order compound arguments" *
+          test_suite("compound_arguments")) {
   argparse::ArgumentParser program("test");
 
   program.add_argument("-a")
@@ -101,10 +108,11 @@ DOCTEST_TEST_CASE("Parse out-of-order compound arguments [compound_arguments]") 
   auto c = program.get<std::vector<float>>("-c");  // {3.14f, 2.718f}
   REQUIRE(a == true);
   REQUIRE(b == true);
-  REQUIRE(program["-c"] == std::vector<float>{3.14f, 2.718f});  
+  REQUIRE(program["-c"] == std::vector<float>{3.14f, 2.718f});
 }
 
-DOCTEST_TEST_CASE("Parse out-of-order compound arguments. Second variation [compound_arguments]") {
+TEST_CASE("Parse out-of-order compound arguments. Second variation" *
+          test_suite("compound_arguments")) {
   argparse::ArgumentParser program("test");
 
   program.add_argument("-a")

--- a/test/test_container_arguments.cpp
+++ b/test/test_container_arguments.cpp
@@ -2,7 +2,9 @@
 #include <argparse.hpp>
 #include <test_utility.hpp>
 
-DOCTEST_TEST_CASE("Parse vector of arguments [vector]") {
+using doctest::test_suite;
+
+TEST_CASE("Parse vector of arguments" * test_suite("vector")) {
   argparse::ArgumentParser program("test");
   program.add_argument("input")
     .nargs(2);
@@ -15,7 +17,7 @@ DOCTEST_TEST_CASE("Parse vector of arguments [vector]") {
   REQUIRE(inputs[1] == "thrust_profile.csv");
 }
 
-DOCTEST_TEST_CASE("Parse list of arguments [vector]") {
+TEST_CASE("Parse list of arguments" * test_suite("vector")) {
   argparse::ArgumentParser program("test");
   program.add_argument("input")
     .nargs(2);
@@ -28,7 +30,8 @@ DOCTEST_TEST_CASE("Parse list of arguments [vector]") {
   REQUIRE(testutility::get_from_list(inputs, 1) == "thrust_profile.csv");
 }
 
-DOCTEST_TEST_CASE("Parse list of arguments with default values [vector]") {
+TEST_CASE("Parse list of arguments with default values" *
+          test_suite("vector")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--input")
     .default_value(std::list<int>{1, 2, 3, 4, 5})
@@ -46,7 +49,8 @@ DOCTEST_TEST_CASE("Parse list of arguments with default values [vector]") {
   REQUIRE(program["--input"] == std::list<int>{1, 2, 3, 4, 5});
 }
 
-DOCTEST_TEST_CASE("Parse list of arguments and save in an object [vector]") {
+TEST_CASE("Parse list of arguments and save in an object" *
+          test_suite("vector")) {
 
   struct ConfigManager {
     std::vector<std::string> files;

--- a/test/test_help.cpp
+++ b/test/test_help.cpp
@@ -1,7 +1,9 @@
 #include <doctest.hpp>
 #include <argparse.hpp>
 
-DOCTEST_TEST_CASE("Users can format help message [help]") {
+using doctest::test_suite;
+
+TEST_CASE("Users can format help message" * test_suite("help")) {
   argparse::ArgumentParser program("test");
   program.add_argument("input")
     .help("positional input");

--- a/test/test_invalid_arguments.cpp
+++ b/test/test_invalid_arguments.cpp
@@ -1,7 +1,10 @@
 #include <doctest.hpp>
 #include <argparse.hpp>
 
-DOCTEST_TEST_CASE("Parse unknown optional argument [compound_arguments]") {
+using doctest::test_suite;
+
+TEST_CASE("Parse unknown optional argument" *
+          test_suite("compound_arguments")) {
 
   argparse::ArgumentParser bfm("bfm");
 

--- a/test/test_issue_37.cpp
+++ b/test/test_issue_37.cpp
@@ -1,7 +1,9 @@
 #include <doctest.hpp>
 #include <argparse.hpp>
 
-DOCTEST_TEST_CASE("Issues with implicit values #37 [implicit_values]") {
+using doctest::test_suite;
+
+TEST_CASE("Issues with implicit values #37" * test_suite("implicit_values")) {
   argparse::ArgumentParser m_bfm("test");
   m_bfm.add_argument("-l", "--load")
     .help("load a VMM into the kernel");

--- a/test/test_negative_numbers.cpp
+++ b/test/test_negative_numbers.cpp
@@ -1,7 +1,9 @@
 #include <doctest.hpp>
 #include <argparse.hpp>
 
-DOCTEST_TEST_CASE("Parse negative integer [positional_arguments]") {
+using doctest::test_suite;
+
+TEST_CASE("Parse negative integer" * test_suite("positional_arguments")) {
   argparse::ArgumentParser program;
   program.add_argument("--verbose", "-v")
     .help("enable verbose logging")
@@ -16,7 +18,8 @@ DOCTEST_TEST_CASE("Parse negative integer [positional_arguments]") {
   REQUIRE(program.get<int>("number") == -1);
 }
 
-DOCTEST_TEST_CASE("Parse negative integers into a vector [positional_arguments]") {
+TEST_CASE("Parse negative integers into a vector" *
+          test_suite("positional_arguments")) {
   argparse::ArgumentParser program;
   program.add_argument("--verbose", "-v")
     .help("enable verbose logging")
@@ -32,7 +35,7 @@ DOCTEST_TEST_CASE("Parse negative integers into a vector [positional_arguments]"
   REQUIRE(program["number"] == std::vector<int>{-1, -2, 3});
 }
 
-DOCTEST_TEST_CASE("Parse negative float [positional_arguments]") {
+TEST_CASE("Parse negative float" * test_suite("positional_arguments")) {
   argparse::ArgumentParser program;
   program.add_argument("--verbose", "-v")
     .help("enable verbose logging")
@@ -47,7 +50,8 @@ DOCTEST_TEST_CASE("Parse negative float [positional_arguments]") {
   REQUIRE(program.get<float>("number") == -1.0);
 }
 
-DOCTEST_TEST_CASE("Parse negative floats into a vector [positional_arguments]") {
+TEST_CASE("Parse negative floats into a vector" *
+          test_suite("positional_arguments")) {
   argparse::ArgumentParser program;
   program.add_argument("--verbose", "-v")
     .help("enable verbose logging")
@@ -63,7 +67,7 @@ DOCTEST_TEST_CASE("Parse negative floats into a vector [positional_arguments]") 
   REQUIRE(program["number"] == std::vector<double>{-1.001, -2.002, 3.003});
 }
 
-DOCTEST_TEST_CASE("Parse numbers in E notation [positional_arguments]") {
+TEST_CASE("Parse numbers in E notation" * test_suite("positional_arguments")) {
   argparse::ArgumentParser program;
   program.add_argument("--verbose", "-v")
     .help("enable verbose logging")
@@ -78,7 +82,8 @@ DOCTEST_TEST_CASE("Parse numbers in E notation [positional_arguments]") {
   REQUIRE(program.get<double>("number") == -1200.0);
 }
 
-DOCTEST_TEST_CASE("Parse numbers in E notation (capital E) [positional_arguments]") {
+TEST_CASE("Parse numbers in E notation (capital E)" *
+          test_suite("positional_arguments")) {
   argparse::ArgumentParser program;
   program.add_argument("--verbose", "-v")
     .help("enable verbose logging")

--- a/test/test_optional_arguments.cpp
+++ b/test/test_optional_arguments.cpp
@@ -1,7 +1,10 @@
 #include <doctest.hpp>
 #include <argparse.hpp>
 
-DOCTEST_TEST_CASE("Parse toggle arguments with default value [optional_arguments]") {
+using doctest::test_suite;
+
+TEST_CASE("Parse toggle arguments with default value" *
+          test_suite("optional_arguments")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--verbose", "-v")
     .default_value(false)
@@ -12,14 +15,16 @@ DOCTEST_TEST_CASE("Parse toggle arguments with default value [optional_arguments
   REQUIRE(program["--verbose"] == false);
 }
 
-DOCTEST_TEST_CASE("Argument '-' is not an optional argument [optional_arguments]") {
+TEST_CASE("Argument '-' is not an optional argument" *
+          test_suite("optional_arguments")) {
   argparse::ArgumentParser program("test");
   program.add_argument("input");
   program.parse_args({ "./test.exe", "-"});
   REQUIRE(program.get<std::string>("input") == "-");
 }
 
-DOCTEST_TEST_CASE("Argument '-' is not an optional argument but '-l' is [optional_arguments]") {
+TEST_CASE("Argument '-' is not an optional argument but '-l' is" *
+          test_suite("optional_arguments")) {
   argparse::ArgumentParser program("test");
   program.add_argument("-l")
     .default_value(false)
@@ -30,7 +35,8 @@ DOCTEST_TEST_CASE("Argument '-' is not an optional argument but '-l' is [optiona
   REQUIRE(program.get<std::string>("input") == "-");
 }
 
-DOCTEST_TEST_CASE("Argument '-l' is an optional argument but '-' is not [optional_arguments]") {
+TEST_CASE("Argument '-l' is an optional argument but '-' is not" *
+          test_suite("optional_arguments")) {
   argparse::ArgumentParser program("test");
   program.add_argument("-l")
     .default_value(false)
@@ -41,7 +47,8 @@ DOCTEST_TEST_CASE("Argument '-l' is an optional argument but '-' is not [optiona
   REQUIRE(program.get<std::string>("input") == "-");
 }
 
-DOCTEST_TEST_CASE("Parse toggle arguments with implicit value [optional_arguments]") {
+TEST_CASE("Parse toggle arguments with implicit value" *
+          test_suite("optional_arguments")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--verbose")
     .default_value(false)
@@ -53,7 +60,8 @@ DOCTEST_TEST_CASE("Parse toggle arguments with implicit value [optional_argument
   REQUIRE(program["--verbose"] != false);
 }
 
-DOCTEST_TEST_CASE("Parse multiple toggle arguments with implicit values [optional_arguments]") {
+TEST_CASE("Parse multiple toggle arguments with implicit values" *
+          test_suite("optional_arguments")) {
   argparse::ArgumentParser program("test");
   program.add_argument("-a")
     .default_value(false)
@@ -73,7 +81,8 @@ DOCTEST_TEST_CASE("Parse multiple toggle arguments with implicit values [optiona
   REQUIRE(program.get<bool>("-x") == true);
 }
 
-DOCTEST_TEST_CASE("Parse optional arguments of many values [optional_arguments]") {
+TEST_CASE("Parse optional arguments of many values" *
+          test_suite("optional_arguments")) {
   GIVEN("a program that accepts an optional argument of many values") {
     argparse::ArgumentParser program("test");
     program.add_argument("-i").remaining().action(
@@ -102,7 +111,8 @@ DOCTEST_TEST_CASE("Parse optional arguments of many values [optional_arguments]"
   }
 }
 
-DOCTEST_TEST_CASE("Parse arguments of different types [optional_arguments]") {
+TEST_CASE("Parse arguments of different types" *
+          test_suite("optional_arguments")) {
   using namespace std::literals;
 
   argparse::ArgumentParser program("test");

--- a/test/test_parent_parsers.cpp
+++ b/test/test_parent_parsers.cpp
@@ -1,7 +1,9 @@
 #include <doctest.hpp>
 #include <argparse.hpp>
 
-DOCTEST_TEST_CASE("Add parent parsers [parent_parsers]") {
+using doctest::test_suite;
+
+TEST_CASE("Add parent parsers" * test_suite("parent_parsers")) {
   argparse::ArgumentParser parent_parser("main");
   parent_parser.add_argument("--verbose")
     .default_value(false)
@@ -14,7 +16,8 @@ DOCTEST_TEST_CASE("Add parent parsers [parent_parsers]") {
   REQUIRE(parent_parser["--verbose"] == false);
 }
 
-DOCTEST_TEST_CASE("Add parent to multiple parent parsers [parent_parsers]") {
+TEST_CASE("Add parent to multiple parent parsers" *
+          test_suite("parent_parsers")) {
   argparse::ArgumentParser parent_parser("main");
   parent_parser.add_argument("--parent")
     .default_value(0)

--- a/test/test_parse_args.cpp
+++ b/test/test_parse_args.cpp
@@ -1,14 +1,17 @@
 #include <doctest.hpp>
 #include <argparse.hpp>
 
-DOCTEST_TEST_CASE("Parse a string argument with value [parse_args]") {
+using doctest::test_suite;
+
+TEST_CASE("Parse a string argument with value" * test_suite("parse_args")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--config");
   program.parse_args({ "test", "--config", "config.yml"});
   REQUIRE(program.get("--config") == "config.yml");
 }
 
-DOCTEST_TEST_CASE("Parse a string argument with default value [parse_args]") {
+TEST_CASE("Parse a string argument with default value" *
+          test_suite("parse_args")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--config")
     .default_value(std::string("foo.yml"));
@@ -16,7 +19,7 @@ DOCTEST_TEST_CASE("Parse a string argument with default value [parse_args]") {
   REQUIRE(program.get("--config") == "foo.yml");
 }
 
-DOCTEST_TEST_CASE("Parse an int argument with value [parse_args]") {
+TEST_CASE("Parse an int argument with value" * test_suite("parse_args")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--count")
     .action([](const std::string& value) { return std::stoi(value); });
@@ -24,7 +27,8 @@ DOCTEST_TEST_CASE("Parse an int argument with value [parse_args]") {
   REQUIRE(program.get<int>("--count") == 5);
 }
 
-DOCTEST_TEST_CASE("Parse an int argument with default value [parse_args]") {
+TEST_CASE("Parse an int argument with default value" *
+          test_suite("parse_args")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--count")
     .default_value(2)
@@ -33,7 +37,7 @@ DOCTEST_TEST_CASE("Parse an int argument with default value [parse_args]") {
   REQUIRE(program.get<int>("--count") == 2);
 }
 
-DOCTEST_TEST_CASE("Parse a float argument with value [parse_args]") {
+TEST_CASE("Parse a float argument with value" * test_suite("parse_args")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--ratio")
     .action([](const std::string& value) { return std::stof(value); });
@@ -41,7 +45,8 @@ DOCTEST_TEST_CASE("Parse a float argument with value [parse_args]") {
   REQUIRE(program.get<float>("--ratio") == 5.6645f);
 }
 
-DOCTEST_TEST_CASE("Parse a float argument with default value [parse_args]") {
+TEST_CASE("Parse a float argument with default value" *
+          test_suite("parse_args")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--ratio")
     .default_value(3.14f)
@@ -50,7 +55,7 @@ DOCTEST_TEST_CASE("Parse a float argument with default value [parse_args]") {
   REQUIRE(program.get<float>("--ratio") == 3.14f);
 }
 
-DOCTEST_TEST_CASE("Parse a double argument with value [parse_args]") {
+TEST_CASE("Parse a double argument with value" * test_suite("parse_args")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--ratio")
     .action([](const std::string& value) { return std::stod(value); });
@@ -58,7 +63,8 @@ DOCTEST_TEST_CASE("Parse a double argument with value [parse_args]") {
   REQUIRE(program.get<double>("--ratio") == 5.6645);
 }
 
-DOCTEST_TEST_CASE("Parse a double argument with default value [parse_args]") {
+TEST_CASE("Parse a double argument with default value" *
+          test_suite("parse_args")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--ratio")
     .default_value(3.14)
@@ -67,7 +73,7 @@ DOCTEST_TEST_CASE("Parse a double argument with default value [parse_args]") {
   REQUIRE(program.get<double>("--ratio") == 3.14);
 }
 
-DOCTEST_TEST_CASE("Parse a vector of integer arguments [parse_args]") {
+TEST_CASE("Parse a vector of integer arguments" * test_suite("parse_args")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--vector")
     .nargs(5)
@@ -82,7 +88,7 @@ DOCTEST_TEST_CASE("Parse a vector of integer arguments [parse_args]") {
   REQUIRE(vector[4] == 5);
 }
 
-DOCTEST_TEST_CASE("Parse a vector of float arguments [parse_args]") {
+TEST_CASE("Parse a vector of float arguments" * test_suite("parse_args")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--vector")
     .nargs(5)
@@ -97,7 +103,7 @@ DOCTEST_TEST_CASE("Parse a vector of float arguments [parse_args]") {
   REQUIRE(vector[4] == 5.5f);
 }
 
-DOCTEST_TEST_CASE("Parse a vector of double arguments [parse_args]") {
+TEST_CASE("Parse a vector of double arguments" * test_suite("parse_args")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--vector")
     .nargs(5)
@@ -112,7 +118,7 @@ DOCTEST_TEST_CASE("Parse a vector of double arguments [parse_args]") {
   REQUIRE(vector[4] == 5.5);
 }
 
-DOCTEST_TEST_CASE("Parse a vector of string arguments [parse_args]") {
+TEST_CASE("Parse a vector of string arguments" * test_suite("parse_args")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--vector")
     .nargs(5)
@@ -127,7 +133,7 @@ DOCTEST_TEST_CASE("Parse a vector of string arguments [parse_args]") {
   REQUIRE(vector[4] == "mno");
 }
 
-DOCTEST_TEST_CASE("Parse a vector of character arguments [parse_args]") {
+TEST_CASE("Parse a vector of character arguments" * test_suite("parse_args")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--vector")
     .nargs(5)
@@ -142,7 +148,8 @@ DOCTEST_TEST_CASE("Parse a vector of character arguments [parse_args]") {
   REQUIRE(vector[4] == 'e');
 }
 
-DOCTEST_TEST_CASE("Parse a vector of string arguments and construct objects [parse_args]") {
+TEST_CASE("Parse a vector of string arguments and construct objects" *
+          test_suite("parse_args")) {
 
   class Foo {
   public:

--- a/test/test_positional_arguments.cpp
+++ b/test/test_positional_arguments.cpp
@@ -2,7 +2,9 @@
 #include <argparse.hpp>
 #include <cmath>
 
-DOCTEST_TEST_CASE("Parse positional arguments [positional_arguments]") {
+using doctest::test_suite;
+
+TEST_CASE("Parse positional arguments" * test_suite("positional_arguments")) {
   argparse::ArgumentParser program("test");
   program.add_argument("input");
   program.add_argument("output");
@@ -11,7 +13,8 @@ DOCTEST_TEST_CASE("Parse positional arguments [positional_arguments]") {
   REQUIRE(program.get("output") == "thrust_profile.csv");
 }
 
-DOCTEST_TEST_CASE("Parse positional arguments with fixed nargs [positional_arguments]") {
+TEST_CASE("Parse positional arguments with fixed nargs" *
+          test_suite("positional_arguments")) {
   argparse::ArgumentParser program("test");
   program.add_argument("input");
   program.add_argument("output").nargs(2);
@@ -23,7 +26,8 @@ DOCTEST_TEST_CASE("Parse positional arguments with fixed nargs [positional_argum
   REQUIRE(outputs[1] == "output.mesh");
 }
 
-DOCTEST_TEST_CASE("Parse positional arguments with optional arguments [positional_arguments]") {
+TEST_CASE("Parse positional arguments with optional arguments" *
+          test_suite("positional_arguments")) {
   argparse::ArgumentParser program("test");
   program.add_argument("input");
   program.add_argument("output").nargs(2);
@@ -38,7 +42,8 @@ DOCTEST_TEST_CASE("Parse positional arguments with optional arguments [positiona
   REQUIRE(outputs[1] == "output.mesh");
 }
 
-DOCTEST_TEST_CASE("Parse positional arguments with optional arguments in the middle [positional_arguments]") {
+TEST_CASE("Parse positional arguments with optional arguments in the middle" *
+          test_suite("positional_arguments")) {
   argparse::ArgumentParser program("test");
   program.add_argument("input");
   program.add_argument("output").nargs(2);
@@ -47,7 +52,8 @@ DOCTEST_TEST_CASE("Parse positional arguments with optional arguments in the mid
   REQUIRE_THROWS(program.parse_args({ "test", "rocket.mesh", "thrust_profile.csv", "--num_iterations", "15", "output.mesh" }));
 }
 
-DOCTEST_TEST_CASE("Parse remaining arguments deemed positional [positional_arguments]") {
+TEST_CASE("Parse remaining arguments deemed positional" *
+          test_suite("positional_arguments")) {
   GIVEN("a program that accepts an optional argument and remaining arguments") {
     argparse::ArgumentParser program("test");
     program.add_argument("-o");
@@ -94,12 +100,13 @@ DOCTEST_TEST_CASE("Parse remaining arguments deemed positional [positional_argum
   }
 }
 
-DOCTEST_TEST_CASE("Negative nargs is not allowed [positional_arguments]") {
+TEST_CASE("Negative nargs is not allowed" *
+          test_suite("positional_arguments")) {
   argparse::ArgumentParser program("test");
   REQUIRE_THROWS_AS(program.add_argument("output").nargs(-1), std::logic_error);
 }
 
-DOCTEST_TEST_CASE("Square a number [positional_arguments]") {
+TEST_CASE("Square a number" * test_suite("positional_arguments")) {
   argparse::ArgumentParser program;
   program.add_argument("--verbose", "-v")
     .help("enable verbose logging")

--- a/test/test_required_arguments.cpp
+++ b/test/test_required_arguments.cpp
@@ -1,44 +1,63 @@
 #include <doctest.hpp>
 #include <argparse.hpp>
 
-DOCTEST_TEST_CASE("Parse required arguments which are not set and don't have default value. [required_arguments]") {
-	argparse::ArgumentParser program("test");
-	program.add_argument("--output", "-o").required();
-	REQUIRE_THROWS(program.parse_args({ "./main" }));
+using doctest::test_suite;
+
+TEST_CASE(
+    "Parse required arguments which are not set and don't have default value" *
+    test_suite("required_arguments")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--output", "-o").required();
+  REQUIRE_THROWS(program.parse_args({"./main"}));
 }
 
-DOCTEST_TEST_CASE("Parse required arguments which are set as empty value and don't have default value. [required_arguments]") {
-	argparse::ArgumentParser program("test");
-	program.add_argument("--output", "-o").required();
-	REQUIRE_THROWS(program.parse_args({ "./main", "-o" }));
+TEST_CASE("Parse required arguments which are set as empty value and don't "
+          "have default value" *
+          test_suite("required_arguments")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--output", "-o").required();
+  REQUIRE_THROWS(program.parse_args({"./main", "-o"}));
 }
 
-DOCTEST_TEST_CASE("Parse required arguments which are set as some value and don't have default value. [required_arguments]") {
-	argparse::ArgumentParser program("test");
-	program.add_argument("--output", "-o").required();
-	program.parse_args({ "./main", "-o", "filename" });
-	REQUIRE(program.get("--output") == "filename");
-	REQUIRE(program.get("-o") == "filename");
+TEST_CASE("Parse required arguments which are set as some value and don't have "
+          "default value" *
+          test_suite("required_arguments")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--output", "-o").required();
+  program.parse_args({"./main", "-o", "filename"});
+  REQUIRE(program.get("--output") == "filename");
+  REQUIRE(program.get("-o") == "filename");
 }
 
-DOCTEST_TEST_CASE("Parse required arguments which are not set and have default value. [required_arguments]") {
-	argparse::ArgumentParser program("test");
-	program.add_argument("--output", "-o").required().default_value(std::string("filename"));
-	program.parse_args({ "./main" });
-	REQUIRE(program.get("--output") == "filename");
-	REQUIRE(program.get("-o") == "filename");
+TEST_CASE("Parse required arguments which are not set and have default value" *
+          test_suite("required_arguments")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--output", "-o")
+      .required()
+      .default_value(std::string("filename"));
+  program.parse_args({"./main"});
+  REQUIRE(program.get("--output") == "filename");
+  REQUIRE(program.get("-o") == "filename");
 }
 
-DOCTEST_TEST_CASE("Parse required arguments which are set as empty and have default value. [required_arguments]") {
-	argparse::ArgumentParser program("test");
-	program.add_argument("--output", "-o").required().default_value(std::string("filename"));
-	REQUIRE_THROWS(program.parse_args({ "./main", "-o" }));
+TEST_CASE(
+    "Parse required arguments which are set as empty and have default value" *
+    test_suite("required_arguments")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--output", "-o")
+      .required()
+      .default_value(std::string("filename"));
+  REQUIRE_THROWS(program.parse_args({"./main", "-o"}));
 }
 
-DOCTEST_TEST_CASE("Parse required arguments which are set as some value and have default value. [required_arguments]") {
-	argparse::ArgumentParser program("test");
-	program.add_argument("--output", "-o").required().default_value(std::string("filename"));
-	program.parse_args({ "./main", "-o", "anotherfile" });
-	REQUIRE(program.get("--output") == "anotherfile");
-	REQUIRE(program.get("-o") == "anotherfile");
+TEST_CASE("Parse required arguments which are set as some value and have "
+          "default value" *
+          test_suite("required_arguments")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--output", "-o")
+      .required()
+      .default_value(std::string("filename"));
+  program.parse_args({"./main", "-o", "anotherfile"});
+  REQUIRE(program.get("--output") == "anotherfile");
+  REQUIRE(program.get("-o") == "anotherfile");
 }

--- a/test/test_value_semantics.cpp
+++ b/test/test_value_semantics.cpp
@@ -1,7 +1,10 @@
 #include <argparse.hpp>
 #include <doctest.hpp>
 
-DOCTEST_TEST_CASE("ArgumentParser is MoveConstructible and MoveAssignable [value_semantics]") {
+using doctest::test_suite;
+
+TEST_CASE("ArgumentParser is MoveConstructible and MoveAssignable" *
+          test_suite("value_semantics")) {
   GIVEN("a parser that has two arguments") {
     argparse::ArgumentParser parser("test");
     parser.add_argument("foo");
@@ -32,7 +35,8 @@ DOCTEST_TEST_CASE("ArgumentParser is MoveConstructible and MoveAssignable [value
   }
 }
 
-DOCTEST_TEST_CASE("ArgumentParser is CopyConstructible and CopyAssignable [value_semantics]") {
+TEST_CASE("ArgumentParser is CopyConstructible and CopyAssignable" *
+          test_suite("value_semantics")) {
   GIVEN("a parser that has two arguments") {
     argparse::ArgumentParser parser("test");
     parser.add_argument("foo");


### PR DESCRIPTION
This change also explicitly lists the source files
for CMake.  This is because `GLOB` does not remove
old files when switching branches in Git, and
`CONFIGURE_DEPENDS` will add unstaged files after
stashing.

See also: https://cmake.org/cmake/help/latest/command/file.html#glob

(I can add the `DOCTEST_` prefix back if you like it;
but don't think it matters though, every unit test
framework uses `TEST_CASE`...)

PS: how to use:
`build/test/tests -ltc` -- list test cases
`build/test/tests -lts` -- list test suites
`build/test/tests -ts=actions`  -- run all tests in `test_suite("actions")`