### PR TITLE
Fix print_help for printing nothing

### DIFF
--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -515,8 +515,8 @@ public:
   }
 
   // Format help message
-  auto help() const -> std::ostringstream {
-    std::ostringstream out;
+  auto help() const -> std::stringstream {
+    std::stringstream out;
     out << *this;
     return out;
   }


### PR DESCRIPTION
Emergent.  The deprecated (therefore untested) `print_help` wasn't printing anything because reading from `ostringstream` is allowed but does nothing.  Sorry about this negligence.