### PR TITLE
Default --help to print help and exit

### DIFF
--- a/test/test_help.cpp
+++ b/test/test_help.cpp
@@ -17,3 +17,27 @@ TEST_CASE("Users can format help message" * test_suite("help")) {
   auto msg = program.help().str();
   REQUIRE(msg == s.str());
 }
+
+TEST_CASE("Users can override the help options" * test_suite("help")) {
+  GIVEN("a program that meant to take -h as a normal option") {
+    argparse::ArgumentParser program("test");
+    program.add_argument("input");
+    program.add_argument("-h").implicit_value('h').default_value('x');
+
+    WHEN("provided -h without fulfilling other requirements") {
+      THEN("validation fails") {
+        REQUIRE_THROWS_AS(program.parse_args({"test", "-h"}),
+                          std::runtime_error);
+      }
+    }
+
+    WHEN("provided arguments to all parameters") {
+      program.parse_args({"test", "-h", "some input"});
+
+      THEN("these parameters get their values") {
+        REQUIRE(program["-h"] == 'h');
+        REQUIRE(program.get("input") == "some input");
+      }
+    }
+  }
+}


### PR DESCRIPTION
The change also fixes a rare bug introduced in 9007958:
when there are duplicated keys, insert_or_update overrides
previously inserted ones, emplace doesn't.

fixes: p-ranav/argparse#59