### PR TITLE
Simplify parsing numeric arguments with .scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ matrix:
       dist: bionic
       language: cpp
       compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env: CXX=g++-8 CC=gcc-8
     - os: osx
       osx_image: xcode10.2
       language: cpp

--- a/README.md
+++ b/README.md
@@ -587,10 +587,13 @@ $ ./main fex
 baz
 ```
 
-## Supported Compilers
-* GCC >= 7.0.0
-* Clang >= 4.0
-* MSVC >= 2017
+## Supported Toolchains
+
+| Compiler             | Standard Library | Test Environment   |
+| :------------------- | :--------------- | :----------------- |
+| GCC >= 8.3.0         | libstdc++        | Ubuntu 18.04       |
+| Clang >= 7.0.0       | libc++           | Xcode 10.2         |
+| MSVC >= 14.16        | Microsoft STL    | Visual Studio 2017 |
 
 ## Contributing
 Contributions are welcome, have a look at the [CONTRIBUTING.md](CONTRIBUTING.md) document for more information.

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -30,6 +30,7 @@ SOFTWARE.
 #pragma once
 #include <algorithm>
 #include <any>
+#include <charconv>
 #include <cstdlib>
 #include <functional>
 #include <iostream>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ file(GLOB ARGPARSE_TEST_SOURCES
     test_parse_args.cpp
     test_positional_arguments.cpp
     test_required_arguments.cpp
+    test_scan.cpp
     test_value_semantics.cpp
 )
 set_source_files_properties(main.cpp

--- a/test/test_scan.cpp
+++ b/test/test_scan.cpp
@@ -1,0 +1,173 @@
+#include <argparse.hpp>
+#include <doctest.hpp>
+#include <stdint.h>
+
+using doctest::test_suite;
+
+TEST_CASE_TEMPLATE("Parse a decimal integer argument" * test_suite("scan"), T,
+                   int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
+                   uint32_t, uint64_t) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("-n").scan<'d', T>();
+
+  SUBCASE("zero") {
+    program.parse_args({"test", "-n", "0"});
+    REQUIRE(program.get<T>("-n") == 0);
+  }
+
+  SUBCASE("non-negative") {
+    program.parse_args({"test", "-n", "5"});
+    REQUIRE(program.get<T>("-n") == 5);
+  }
+
+  SUBCASE("negative") {
+    if constexpr (std::is_signed_v<T>) {
+      program.parse_args({"test", "-n", "-128"});
+      REQUIRE(program.get<T>("-n") == -128);
+    } else {
+      REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "-135"}),
+                        std::invalid_argument);
+    }
+  }
+
+  SUBCASE("left-padding is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", " 32"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("right-padding is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "12 "}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("plus sign is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "+12"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("does not fit") {
+    REQUIRE_THROWS_AS(
+        program.parse_args({"test", "-n", "987654321987654321987654321"}),
+        std::range_error);
+  }
+}
+
+TEST_CASE_TEMPLATE("Parse an octal integer argument" * test_suite("scan"), T,
+                   uint8_t, uint16_t, uint32_t, uint64_t) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("-n").scan<'o', T>();
+
+  SUBCASE("zero") {
+    program.parse_args({"test", "-n", "0"});
+    REQUIRE(program.get<T>("-n") == 0);
+  }
+
+  SUBCASE("with octal base") {
+    program.parse_args({"test", "-n", "066"});
+    REQUIRE(program.get<T>("-n") == 066);
+  }
+
+  SUBCASE("minus sign produces an optional argument") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "-003"}),
+                      std::runtime_error);
+  }
+
+  SUBCASE("plus sign is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "+012"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("does not fit") {
+    REQUIRE_THROWS_AS(
+        program.parse_args({"test", "-n", "02000000000000000000001"}),
+        std::range_error);
+  }
+}
+
+TEST_CASE_TEMPLATE("Parse a hexadecimal integer argument" * test_suite("scan"),
+                   T, uint8_t, uint16_t, uint32_t, uint64_t) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("-n").scan<'X', T>();
+
+  SUBCASE("with hex digit") {
+    program.parse_args({"test", "-n", "0x1a"});
+    REQUIRE(program.get<T>("-n") == 0x1a);
+  }
+
+  SUBCASE("minus sign produces an optional argument") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "-0x1"}),
+                      std::runtime_error);
+  }
+
+  SUBCASE("plus sign is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "+0x1a"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("does not fit") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "0XFFFFFFFFFFFFFFFF1"}),
+                      std::range_error);
+  }
+}
+
+TEST_CASE_TEMPLATE("Parse integer argument of any format" * test_suite("scan"),
+                   T, int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
+                   uint32_t, uint64_t) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("-n").scan<'i', T>();
+
+  SUBCASE("zero") {
+    program.parse_args({"test", "-n", "0"});
+    REQUIRE(program.get<T>("-n") == 0);
+  }
+
+  SUBCASE("octal") {
+    program.parse_args({"test", "-n", "077"});
+    REQUIRE(program.get<T>("-n") == 077);
+  }
+
+  SUBCASE("no negative octal") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "-0777"}),
+                      std::runtime_error);
+  }
+
+  SUBCASE("hex") {
+    program.parse_args({"test", "-n", "0X2c"});
+    REQUIRE(program.get<T>("-n") == 0X2c);
+  }
+
+  SUBCASE("no negative hex") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "-0X2A"}),
+                      std::runtime_error);
+  }
+
+  SUBCASE("decimal") {
+    program.parse_args({"test", "-n", "98"});
+    REQUIRE(program.get<T>("-n") == 98);
+  }
+
+  SUBCASE("negative decimal") {
+    if constexpr (std::is_signed_v<T>) {
+      program.parse_args({"test", "-n", "-39"});
+      REQUIRE(program.get<T>("-n") == -39);
+    } else {
+      REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "-39"}),
+                        std::invalid_argument);
+    }
+  }
+
+  SUBCASE("left-padding is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "\t32"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("right-padding is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "32\n"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("plus sign is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "+670"}),
+                      std::invalid_argument);
+  }
+}

--- a/test/test_scan.cpp
+++ b/test/test_scan.cpp
@@ -171,3 +171,178 @@ TEST_CASE_TEMPLATE("Parse integer argument of any format" * test_suite("scan"),
                       std::invalid_argument);
   }
 }
+
+#define FLOAT_G(t, literal)                                                    \
+  ([] {                                                                        \
+    if constexpr (std::is_same_v<t, float>)                                    \
+      return literal##f;                                                       \
+    else if constexpr (std::is_same_v<t, double>)                              \
+      return literal;                                                          \
+    else if constexpr (std::is_same_v<t, long double>)                         \
+      return literal##l;                                                       \
+  }())
+
+TEST_CASE_TEMPLATE("Parse floating-point argument of general format" *
+                       test_suite("scan"),
+                   T, float, double, long double) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("-n").scan<'g', T>();
+
+  SUBCASE("zero") {
+    program.parse_args({"test", "-n", "0"});
+    REQUIRE(program.get<T>("-n") == 0.);
+  }
+
+  SUBCASE("non-negative") {
+    program.parse_args({"test", "-n", "3.14"});
+    REQUIRE(program.get<T>("-n") == FLOAT_G(T, 3.14));
+  }
+
+  SUBCASE("negative") {
+    program.parse_args({"test", "-n", "-0.12"});
+    REQUIRE(program.get<T>("-n") == FLOAT_G(T, -0.12));
+  }
+
+  SUBCASE("left-padding is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "\t.32"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("right-padding is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", ".32\n"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("plus sign is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "+.12"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("plus sign after padding is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "   +.12"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("hexfloat is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "0x1a.3p+1"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("does not fit") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "1.3e+5000"}),
+                      std::range_error);
+  }
+}
+
+TEST_CASE_TEMPLATE("Parse hexadecimal floating-point argument" *
+                       test_suite("scan"),
+                   T, float, double, long double) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("-n").scan<'a', T>();
+
+  SUBCASE("zero") {
+    // binary-exponent-part is not optional in C++ grammar
+    program.parse_args({"test", "-n", "0x0"});
+    REQUIRE(program.get<T>("-n") == 0x0.p0);
+  }
+
+  SUBCASE("non-negative") {
+    program.parse_args({"test", "-n", "0x1a.3p+1"});
+    REQUIRE(program.get<T>("-n") == 0x1a.3p+1);
+  }
+
+  SUBCASE("minus sign produces an optional argument") {
+    // XXX may worth a fix
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "-0x0.12p1"}),
+                      std::runtime_error);
+  }
+
+  SUBCASE("plus sign is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "+0x1p0"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("general format is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "3.14"}),
+                      std::invalid_argument);
+  }
+}
+
+TEST_CASE_TEMPLATE("Parse floating-point argument of scientific format" *
+                       test_suite("scan"),
+                   T, float, double, long double) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("-n").scan<'e', T>();
+
+  SUBCASE("zero") {
+    program.parse_args({"test", "-n", "0e0"});
+    REQUIRE(program.get<T>("-n") == 0e0);
+  }
+
+  SUBCASE("non-negative") {
+    program.parse_args({"test", "-n", "3.14e-1"});
+    REQUIRE(program.get<T>("-n") == FLOAT_G(T, 3.14e-1));
+  }
+
+  SUBCASE("negative") {
+    program.parse_args({"test", "-n", "-0.12e+1"});
+    REQUIRE(program.get<T>("-n") == FLOAT_G(T, -0.12e+1));
+  }
+
+  SUBCASE("plus sign is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "+.12e+1"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("fixed format is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "3.14"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("hexfloat is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "0x1.33p+0"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("does not fit") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "1.3e+5000"}),
+                      std::range_error);
+  }
+}
+
+TEST_CASE_TEMPLATE("Parse floating-point argument of fixed format" *
+                       test_suite("scan"),
+                   T, float, double, long double) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("-n").scan<'f', T>();
+
+  SUBCASE("zero") {
+    program.parse_args({"test", "-n", ".0"});
+    REQUIRE(program.get<T>("-n") == .0);
+  }
+
+  SUBCASE("non-negative") {
+    program.parse_args({"test", "-n", "3.14"});
+    REQUIRE(program.get<T>("-n") == FLOAT_G(T, 3.14));
+  }
+
+  SUBCASE("negative") {
+    program.parse_args({"test", "-n", "-0.12"});
+    REQUIRE(program.get<T>("-n") == FLOAT_G(T, -0.12));
+  }
+
+  SUBCASE("plus sign is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "+.12"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("scientific format is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "3.14e+0"}),
+                      std::invalid_argument);
+  }
+
+  SUBCASE("hexfloat is not allowed") {
+    REQUIRE_THROWS_AS(program.parse_args({"test", "-n", "0x1.33p+0"}),
+                      std::invalid_argument);
+  }
+}


### PR DESCRIPTION
Limitations due to portability :

1. This patch uses `from_chars` for parsing integer numbers.  To do so, I bumped required GCC version to 8.x and required Clang/libc++ version to 7.x.
2. This patch emulates `from_chars` behavior for parsing floating-point numbers with `strtod`, but this function is locale-aware.
3. The emulation does not use strict grammar to distinguish fixed and scientific format.  As a result, `NAN(char_sequence)` (signal NaN, but should be parsed as quiet NaN) may fail to parsed.

Caveats:

1. There is no `base == 0` case for `from_chars`; integer format detection for `'i'` shape is done by hand.
2. Hexfloat is not considered possibly negative as positional argument, so negative hexfloat currently is not a valid input.
3. `+` sign is not allowed, but this is a result of sticking with `from_chars`'s grammar.
4. We throw `range_error` for `ERANGE` and `std::errc::result_out_of_range`, unlike `stoi` and `stod` which throw `out_of_range`.  Our choice is correct here.

fixes: #63 