### PR TITLE
Add the option to add text before and after help output

### DIFF
--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -870,12 +870,10 @@ public:
       for (const auto &argument : parser.mPositionalArguments) {
         stream << argument.mNames.front() << " ";
       }
-      stream << "\n";
+      stream << "\n\n";
 
       if(!parser.mDescription.empty())
-        stream << parser.mDescription << "\n";
-
-      stream << "\n";
+        stream << parser.mDescription << "\n\n";
 
       if (!parser.mPositionalArguments.empty())
         stream << "Positional arguments:\n";

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -800,12 +800,12 @@ public:
     }
   }
 
-  void add_pre_text(std::string aPreText) {
-    mPreText = std::move(aPreText);
+  void add_description(std::string aDescription) {
+    mDescription = std::move(aDescription);
   }
 
-  void add_post_text(std::string aPostText) {
-    mPostText = std::move(aPostText);
+  void add_epilog(std::string aEpilog) {
+    mEpilog = std::move(aEpilog);
   }
 
   /* Call parse_args_internal - which does all the work
@@ -872,8 +872,8 @@ public:
       }
       stream << "\n";
 
-      if(!parser.mPreText.empty())
-        stream << parser.mPreText << "\n";
+      if(!parser.mDescription.empty())
+        stream << parser.mDescription << "\n";
 
       stream << "\n";
 
@@ -894,8 +894,8 @@ public:
         stream << mOptionalArgument;
       }
 
-      if(!parser.mPostText.empty())
-        stream << parser.mPostText << "\n\n";
+      if(!parser.mEpilog.empty())
+        stream << parser.mEpilog << "\n\n";
     }
 
     return stream;
@@ -1004,8 +1004,8 @@ private:
   }
 
   std::string mProgramName;
-  std::string mPreText;
-  std::string mPostText;
+  std::string mDescription;
+  std::string mEpilog;
   std::list<Argument> mPositionalArguments;
   std::list<Argument> mOptionalArguments;
   std::map<std::string_view, list_iterator, std::less<>> mArgumentMap;

--- a/include/argparse.hpp
+++ b/include/argparse.hpp
@@ -800,6 +800,14 @@ public:
     }
   }
 
+  void add_pre_text(std::string aPreText) {
+    mPreText = std::move(aPreText);
+  }
+
+  void add_post_text(std::string aPostText) {
+    mPostText = std::move(aPostText);
+  }
+
   /* Call parse_args_internal - which does all the work
    * Then, validate the parsed arguments
    * This variant is used mainly for testing
@@ -862,7 +870,12 @@ public:
       for (const auto &argument : parser.mPositionalArguments) {
         stream << argument.mNames.front() << " ";
       }
-      stream << "\n\n";
+      stream << "\n";
+
+      if(!parser.mPreText.empty())
+        stream << parser.mPreText << "\n";
+
+      stream << "\n";
 
       if (!parser.mPositionalArguments.empty())
         stream << "Positional arguments:\n";
@@ -880,6 +893,9 @@ public:
         stream.width(tLongestArgumentLength);
         stream << mOptionalArgument;
       }
+
+      if(!parser.mPostText.empty())
+        stream << parser.mPostText << "\n\n";
     }
 
     return stream;
@@ -988,6 +1004,8 @@ private:
   }
 
   std::string mProgramName;
+  std::string mPreText;
+  std::string mPostText;
   std::list<Argument> mPositionalArguments;
   std::list<Argument> mOptionalArguments;
   std::map<std::string_view, list_iterator, std::less<>> mArgumentMap;


### PR DESCRIPTION
It would be nice to add text to the beginning and end of help messages. Many standard *nix tools do this to provide examples, show license information, etc.

For example, the current help output on a firmware programmer I am building:
```
Usage: dev-program [options] FILE

Positional arguments:
FILE                    HEX input file

Optional arguments:
-h --help               show this help message and exit
-l --list-interfaces    List all possible programming interfaces detectable by this program
-d --delay              Amount of time to wait for a device reset for programming, in milliseconds (default 5000)
-r --auto-reset         Attempt to automatically reset the device (depends on programming cable and/or current firmware)
```

Turns into:
```
Usage: dev-program [options] FILE
Internal Device Programmer Version 0.1.0

Examples:
    dev-program -w -v image.hex  # Write image.hex to the device and verify
    dev-program -l               # List all potential programming devices

Positional arguments:
FILE                    HEX input file

Optional arguments:
-h --help               show this help message and exit
-l --list-interfaces    List all possible programming interfaces detectable by this program
-d --delay              Amount of time to wait for a device reset for programming, in milliseconds (default 5000)
-r --auto-reset         Attempt to automatically reset the device (depends on programming cable and/or current firmware)

Please contact HelpDesk@company.com with any questions
Submit any bugs at https://gitlab.company.com/dev-program/issues
```

To add this I added two new string members, and printed them out if they are not empty during the help output. I tried to make sure the formatting remains unchanged if the text is not used. The spacing when used I attempted to make it look like the output of `ls -help` and others.

I did this quickly because I needed it for this current project, so totally open to any suggestions to make it better, or rejection if you don't think it is in scope for your project.