### PR TITLE
Fix incorrect message when mUsedName is empty

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -452,8 +452,10 @@ public:
       } else {
         if (mValues.size() != expected && !mDefaultValue.has_value()) {
           std::stringstream stream;
-          stream << mUsedName << ": expected " << *expected << " argument(s). "
-                 << mValues.size() << " provided.";
+          if (!mUsedName.empty())
+            stream << mUsedName << ": ";
+          stream << *expected << " argument(s) expected. " << mValues.size()
+                 << " provided.";
           throw std::runtime_error(stream.str());
         }
       }


### PR DESCRIPTION
Previously, it printed ": expected 1 argument(s). 0 provided." when one positional argument is defined but nothing is provided. Now it prints "1 argument(s) expected. 0 provided."