### PR TITLE
Fix help if required and def-value. Fixes #89.

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -483,7 +483,7 @@ public:
     std::copy(std::begin(argument.mNames), std::end(argument.mNames),
               std::ostream_iterator<std::string>(nameStream, " "));
     stream << nameStream.str() << "\t" << argument.mHelp;
-    if (argument.mIsRequired)
+    if (argument.mIsRequired && !argument.mDefaultValue.has_value())
       stream << "[Required]";
     stream << "\n";
     return stream;


### PR DESCRIPTION
Propose, skip text `[Required]` if argument has default value,
because the argument can be omitted in commend-line.