### PR TITLE
Add Argument.append method to allow repeated argument use

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,30 @@ if (auto fn = program.present("-o")) {
 
 Similar to `get`, the `present` method also accepts a template argument.  But rather than returning `T`, `parser.present<T>(key)` returns `std::optional<T>`, so that when the user does not provide a value to this parameter, the return value compares equal to `std::nullopt`.
 
+#### Joining values of repeated optional arguments
+
+You may want to allow an optional argument to be repeated and gather all values in one place.
+
+```cpp
+program.add_argument("--color")
+  .default_value<std::vector<std::string>>({ "orange" })
+  .append()
+  .help("specify the cat's fur color");
+
+try {
+  program.parse_args(argc, argv);    // Example: ./main --color red --color green --color blue
+}
+catch (const std::runtime_error& err) {
+  std::cout << err.what() << std::endl;
+  std::cout << program;
+  exit(0);
+}
+
+auto colors = program.get<std::vector<std::string>>("--color");  // {"red", "green", "blue"}
+```
+
+Notice that ```.default_value``` is given an explicit template parameter to match the type you want to ```.get```.
+
 ### Negative Numbers
 
 Optional arguments start with ```-```. Can ```argparse``` handle negative numbers? The answer is yes!

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 file(GLOB ARGPARSE_TEST_SOURCES
     main.cpp
     test_actions.cpp
+    test_append.cpp
     test_compound_arguments.cpp
     test_container_arguments.cpp
     test_help.cpp

--- a/test/test_append.cpp
+++ b/test/test_append.cpp
@@ -1,0 +1,46 @@
+#include <doctest.hpp>
+#include <argparse/argparse.hpp>
+
+using doctest::test_suite;
+
+TEST_CASE("Simplest .append" * test_suite("append")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--dir")
+    .append();
+  program.parse_args({ "test", "--dir", "./Docs" });
+  std::string result { program.get("--dir") };
+  REQUIRE(result == "./Docs");
+}
+
+TEST_CASE("Two parameter .append" * test_suite("append")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--dir")
+    .append();
+  program.parse_args({ "test", "--dir", "./Docs", "--dir", "./Src" });
+  auto result { program.get<std::vector<std::string>>("--dir") };
+  REQUIRE(result.at(0) == "./Docs");
+  REQUIRE(result.at(1) == "./Src");
+}
+
+TEST_CASE("Two int .append" * test_suite("append")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--factor")
+    .append()
+    .action([](auto s) { return stoi(s); });
+  program.parse_args({ "test", "--factor", "2", "--factor", "5" });
+  auto result { program.get<std::vector<int>>("--factor") };
+  REQUIRE(result.at(0) == 2);
+  REQUIRE(result.at(1) == 5);
+}
+
+TEST_CASE("Default value with .append" * test_suite("append")) {
+  std::vector<std::string> expected { "./Src", "./Imgs" };
+
+  argparse::ArgumentParser program("test");
+  program.add_argument("--dir")
+    .default_value(expected)
+    .append();
+  program.parse_args({ "test" });
+  auto result { program.get<std::vector<std::string>>("--dir") };
+  REQUIRE(result == expected);
+}


### PR DESCRIPTION
The default behavior with optional arguments is to allow only a single use
per invocation.  One alternative is to use .nargs, but this requires
previously knowing, and limiting, the quantity of values.  The .append
method removes the restriction on repeats for a single Argument.

Signed-off-by: Sean Robinson <sean.robinson@scottsdalecc.edu>