### PR TITLE
Allow user to limit version argument to --version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,16 @@
 cmake_minimum_required(VERSION 3.8)
 project(argparse VERSION 1.0.0 LANGUAGES CXX)
 option(ARGPARSE_BUILD_TESTS OFF)
+option(ARGPARSE_LONG_VERSION_ARG_ONLY OFF)
 
 include(GNUInstallDirs)
 
 add_library(argparse INTERFACE)
 add_library(argparse::argparse ALIAS argparse)
+
+if (ARGPARSE_LONG_VERSION_ARG_ONLY)
+	target_compile_definitions(argparse INTERFACE ARGPARSE_LONG_VERSION_ARG_ONLY=true)
+endif ()
 
 target_compile_features(argparse INTERFACE cxx_std_17)
 target_include_directories(argparse INTERFACE

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -815,7 +815,11 @@ public:
                           std::string aVersion = "1.0")
       : mProgramName(std::move(aProgramName)), mVersion(std::move(aVersion)) {
     add_argument("-h", "--help").help("shows help message and exits").nargs(0);
+#ifndef ARGPARSE_LONG_VERSION_ARG_ONLY
     add_argument("-v", "--version")
+#else
+	add_argument("--version")
+#endif
         .help("prints version information and exits")
         .nargs(0);
   }


### PR DESCRIPTION
Per https://github.com/p-ranav/argparse/issues/102 -- introduces a compiler directive to allow "--version" to be restricted to the long-form only, and a CMakeLists.txt option for controlling it.

Example with it disabled:

```cmake
set (ARGPARSE_LONG_VERSION_ARG_ONLY ON)
add_subdirectory(argparse)
```

produces:

```
> .\build\cparse\cparse.exe --help
Usage: cparse [options]

Optional arguments:
-h --help       shows help message and exits
--version       prints version information and exits
-v --verbose    Increase output verbosity
-q --quiet      Decrease output verbosity
-G --gui        Enable GUI [default: false]
```

where as without this option on:

```
> .\build\cparse\cparse.exe --help
Usage: cparse [options]

Optional arguments:
-h --help       shows help message and exits
-v --version     prints version information and exits
-v --verbose    Increase output verbosity
-q --quiet      Decrease output verbosity
-G --gui        Enable GUI [default: false]
```