### PR TITLE
Const-correct ArgumentParser

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -925,7 +925,7 @@ public:
    * @throws std::bad_any_cast if the option is not of type T
    */
   template <typename T = std::string>
-  auto present(std::string_view aArgumentName) -> std::optional<T> {
+  auto present(std::string_view aArgumentName) const -> std::optional<T> {
     return (*this)[aArgumentName].present<T>();
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ file(GLOB ARGPARSE_TEST_SOURCES
     test_append.cpp
     test_compound_arguments.cpp
     test_container_arguments.cpp
+    test_const_correct.cpp
     test_help.cpp
     test_invalid_arguments.cpp
     test_is_used.cpp

--- a/test/test_const_correct.cpp
+++ b/test/test_const_correct.cpp
@@ -1,0 +1,27 @@
+#include <argparse/argparse.hpp>
+#include <doctest.hpp>
+
+using doctest::test_suite;
+
+TEST_CASE("ArgumentParser is const-correct after construction and parsing" *
+          test_suite("value_semantics")) {
+  GIVEN("a parser") {
+    argparse::ArgumentParser parser("test");
+    parser.add_argument("--foo", "-f").help("I am foo");
+    parser.add_description("A description");
+    parser.add_epilog("An epilog");
+
+    WHEN("becomes const-qualified") {
+      parser.parse_args({"./main", "--foo", "baz"});
+      const auto const_parser = std::move(parser);
+
+      THEN("only const methods are accessible") {
+        REQUIRE(const_parser.help().str().size() > 0);
+        REQUIRE(const_parser.present<std::string>("--foo"));
+        REQUIRE(const_parser.is_used("-f"));
+        REQUIRE(const_parser.get("-f") == "baz");
+        REQUIRE(const_parser["-f"] == std::string("baz"));
+      }
+    }
+  }
+}

--- a/test/test_value_semantics.cpp
+++ b/test/test_value_semantics.cpp
@@ -93,4 +93,27 @@ TEST_CASE("ArgumentParser is CopyConstructible and CopyAssignable" *
       }
     }
   }
+
+  TEST_CASE("ArgumentParser is const-correct after construction and parsing" *
+            test_suite("value_semantics")) {
+    GIVEN("a parser") {
+      argparse::ArgumentParser parser("test");
+      parser.add_argument("--foo", "-f").help("I am foo");
+      parser.add_description("A description");
+      parser.add_epilog("An epilog");
+
+      WHEN("becomes const-qualified") {
+        parser.parse_args({"./main", "--foo", "baz"});
+        const auto const_parser = std::move(parser);
+
+        THEN("only const methods are accessible") {
+          REQUIRE(const_parser.help().str().size() > 0);
+          REQUIRE(const_parser.present<std::string>("--foo"));
+          REQUIRE(const_parser.is_used("-f"));
+          REQUIRE(const_parser.get("-f") == "baz");
+          REQUIRE(const_parser["-f"] == std::string("baz"));
+        }
+      }
+    }
+  }
 }

--- a/test/test_value_semantics.cpp
+++ b/test/test_value_semantics.cpp
@@ -93,27 +93,4 @@ TEST_CASE("ArgumentParser is CopyConstructible and CopyAssignable" *
       }
     }
   }
-
-  TEST_CASE("ArgumentParser is const-correct after construction and parsing" *
-            test_suite("value_semantics")) {
-    GIVEN("a parser") {
-      argparse::ArgumentParser parser("test");
-      parser.add_argument("--foo", "-f").help("I am foo");
-      parser.add_description("A description");
-      parser.add_epilog("An epilog");
-
-      WHEN("becomes const-qualified") {
-        parser.parse_args({"./main", "--foo", "baz"});
-        const auto const_parser = std::move(parser);
-
-        THEN("only const methods are accessible") {
-          REQUIRE(const_parser.help().str().size() > 0);
-          REQUIRE(const_parser.present<std::string>("--foo"));
-          REQUIRE(const_parser.is_used("-f"));
-          REQUIRE(const_parser.get("-f") == "baz");
-          REQUIRE(const_parser["-f"] == std::string("baz"));
-        }
-      }
-    }
-  }
 }


### PR DESCRIPTION
Hi!

I wished to provide a small contribution to your fine project.

In another project I am currently working on, I stumbled upon a minor inconvenience in `argparse`'s interface. Normally after parsing the parameters one would expect the parser to be immutable (quite understandably so in simple cases). However, I realized a crucial function checking for a value being actually passed by the user is not, though could be, `const`!

I am concerned the test I wrote might actually be meaningless. What one would expect there is for the code to actually compile, nothing more, to validate this change. I could also offer rewriting some tests to try to better comply with `ArgumentParser`'s immutability at some point in their bodies, if you deem that viable or useful in any way.

Cheers!