### PR TITLE
Improve nargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,29 @@ catch (const std::runtime_error& err) {
 auto query_point = program.get<std::vector<double>>("--query_point");  // {3.5, 4.7, 9.2}
 ```
 
+You can also make a variable length list of arguments with the ```.nargs```.
+Below are some examples.
+
+```cpp
+program.add_argument("--input_files")
+  .nargs(1, 3);  // This accepts 1 to 3 arguments.
+```
+
+Some useful patterns are defined like "?", "*", "+" of argparse in Python.
+
+```cpp
+program.add_argument("--input_files")
+  .nargs(argparse::nargs_pattern::any);  // "*" in Python. This accepts any number of arguments including 0.
+```
+```cpp
+program.add_argument("--input_files")
+  .nargs(argparse::nargs_pattern::at_least_one);  // "+" in Python. This accepts one or more number of arguments.
+```
+```cpp
+program.add_argument("--input_files")
+  .nargs(argparse::nargs_pattern::zero_or_one);  // "?" in Python. This accepts an argument optionally.
+```
+
 ### Compound Arguments
 
 Compound arguments are optional arguments that are combined and provided as a single argument. Example: ```ps -aux```

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ program.add_argument("--input_files")
 ```
 ```cpp
 program.add_argument("--input_files")
-  .nargs(argparse::nargs_pattern::zero_or_one);  // "?" in Python. This accepts an argument optionally.
+  .nargs(argparse::nargs_pattern::optional);  // "?" in Python. This accepts an argument optionally.
 ```
 
 ### Compound Arguments

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -318,11 +318,9 @@ class SizeRange {
   std::size_t mMax;
 
 public:
-  SizeRange(std::size_t aMin, std::size_t aMax) {
+  SizeRange(std::size_t aMin, std::size_t aMax) : mMin(aMin), mMax(aMax) {
     if (aMin > aMax)
       throw std::logic_error("Range of number of arguments is invalid");
-    mMin = aMin;
-    mMax = aMax;
   }
 
   bool contains(std::size_t value) const {

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -328,37 +328,6 @@ template <class T> struct parse_number<T, chars_format::fixed> {
 
 } // namespace details
 
-class NArgsRange {
-  std::size_t m_min;
-  std::size_t m_max;
-
-public:
-  NArgsRange(std::size_t minimum, std::size_t maximum) : m_min(minimum), m_max(maximum) {
-    if (minimum > maximum)
-      throw std::logic_error("Range of number of arguments is invalid");
-  }
-
-  bool contains(std::size_t value) const {
-    return value >= m_min && value <= m_max;
-  }
-
-  bool is_exact() const {
-    return m_min == m_max;
-  }
-
-  bool is_right_bounded() const {
-    return m_max < std::numeric_limits<std::size_t>::max();
-  }
-
-  std::size_t get_min() const {
-    return m_min;
-  }
-
-  std::size_t get_max() const {
-    return m_max;
-  }
-};
-
 enum class nargs_pattern {
   optional,
   any,
@@ -497,11 +466,6 @@ public:
 
   Argument &nargs(std::size_t num_args_min, std::size_t num_args_max) {
     m_num_args_range = NArgsRange{num_args_min, num_args_max};
-    return *this;
-  }
-
-  Argument &nargs(NArgsRange num_args_range) {
-    m_num_args_range = num_args_range;
     return *this;
   }
 
@@ -649,6 +613,37 @@ public:
   }
 
 private:
+
+  class NArgsRange {
+    std::size_t m_min;
+    std::size_t m_max;
+
+  public:
+    NArgsRange(std::size_t minimum, std::size_t maximum) : m_min(minimum), m_max(maximum) {
+      if (minimum > maximum)
+        throw std::logic_error("Range of number of arguments is invalid");
+    }
+
+    bool contains(std::size_t value) const {
+      return value >= m_min && value <= m_max;
+    }
+
+    bool is_exact() const {
+      return m_min == m_max;
+    }
+
+    bool is_right_bounded() const {
+      return m_max < std::numeric_limits<std::size_t>::max();
+    }
+
+    std::size_t get_min() const {
+      return m_min;
+    }
+
+    std::size_t get_max() const {
+      return m_max;
+    }
+  };
 
   void throw_nargs_range_validation_error() const {
     std::stringstream stream;

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -328,12 +328,12 @@ template <class T> struct parse_number<T, chars_format::fixed> {
 
 } // namespace details
 
-class SizeRange {
+class NArgsRange {
   std::size_t m_min;
   std::size_t m_max;
 
 public:
-  SizeRange(std::size_t minimum, std::size_t maximum) : m_min(minimum), m_max(maximum) {
+  NArgsRange(std::size_t minimum, std::size_t maximum) : m_min(minimum), m_max(maximum) {
     if (minimum > maximum)
       throw std::logic_error("Range of number of arguments is invalid");
   }
@@ -421,7 +421,7 @@ public:
 
   Argument &implicit_value(std::any value) {
     m_implicit_value = std::move(value);
-    m_num_args_range = SizeRange{0, 0};
+    m_num_args_range = NArgsRange{0, 0};
     return *this;
   }
 
@@ -491,16 +491,16 @@ public:
   }
 
   Argument &nargs(std::size_t num_args) {
-    m_num_args_range = SizeRange{num_args, num_args};
+    m_num_args_range = NArgsRange{num_args, num_args};
     return *this;
   }
 
   Argument &nargs(std::size_t num_args_min, std::size_t num_args_max) {
-    m_num_args_range = SizeRange{num_args_min, num_args_max};
+    m_num_args_range = NArgsRange{num_args_min, num_args_max};
     return *this;
   }
 
-  Argument &nargs(SizeRange num_args_range) {
+  Argument &nargs(NArgsRange num_args_range) {
     m_num_args_range = num_args_range;
     return *this;
   }
@@ -508,13 +508,13 @@ public:
   Argument &nargs(nargs_pattern pattern) {
     switch (pattern) {
     case nargs_pattern::optional:
-      m_num_args_range = SizeRange{0, 1};
+      m_num_args_range = NArgsRange{0, 1};
       break;
     case nargs_pattern::any:
-      m_num_args_range = SizeRange{0, std::numeric_limits<std::size_t>::max()};
+      m_num_args_range = NArgsRange{0, std::numeric_limits<std::size_t>::max()};
       break;
     case nargs_pattern::at_least_one:
-      m_num_args_range = SizeRange{1, std::numeric_limits<std::size_t>::max()};
+      m_num_args_range = NArgsRange{1, std::numeric_limits<std::size_t>::max()};
       break;
     }
     return *this;
@@ -916,7 +916,7 @@ private:
       std::in_place_type<valued_action>,
       [](const std::string &value) { return value; }};
   std::vector<std::any> m_values;
-  SizeRange m_num_args_range {1, 1};
+  NArgsRange m_num_args_range {1, 1};
   bool m_accepts_optional_like_value = false;
   bool m_is_optional : true;
   bool m_is_required : true;

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -588,7 +588,7 @@ public:
       if (!m_is_used && !m_default_value.has_value() && m_is_required) {
         throw_required_arg_not_used_error();
       }
-      if (m_is_used && m_is_required && m_values.size() == 0) {
+      if (m_is_used && m_is_required && m_values.empty()) {
         throw_required_arg_no_value_provided_error();
       }
     } else {

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -836,7 +836,8 @@ private:
       return std::any_cast<T>(mDefaultValue);
     } else {
       if constexpr (details::is_container_v<T>)
-        return any_cast_container<T>(mValues);
+        if (!mAcceptsOptionalLikeValue)
+          return any_cast_container<T>(mValues);
     }
     throw std::logic_error("No value provided for '" + mNames.back() + "'.");
   }

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -360,7 +360,7 @@ public:
 };
 
 enum class nargs_pattern {
-  zero_or_one,
+  optional,
   any,
   at_least_one
 };
@@ -507,7 +507,7 @@ public:
 
   Argument &nargs(nargs_pattern pattern) {
     switch (pattern) {
-    case nargs_pattern::zero_or_one:
+    case nargs_pattern::optional:
       m_num_args_range = SizeRange{0, 1};
       break;
     case nargs_pattern::any:

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -359,10 +359,10 @@ public:
   }
 };
 
-enum class NArgsPattern {
-  ZeroOrOne,
-  Any,
-  AtLeastOne
+enum class nargs_pattern {
+  zero_or_one,
+  any,
+  at_least_one
 };
 
 enum class default_arguments : unsigned int {
@@ -505,15 +505,15 @@ public:
     return *this;
   }
 
-  Argument &nargs(NArgsPattern num_args_pattern) {
-    switch (num_args_pattern) {
-    case NArgsPattern::ZeroOrOne:
+  Argument &nargs(nargs_pattern pattern) {
+    switch (pattern) {
+    case nargs_pattern::zero_or_one:
       m_num_args_range = SizeRange{0, 1};
       break;
-    case NArgsPattern::Any:
+    case nargs_pattern::any:
       m_num_args_range = SizeRange{0, std::numeric_limits<std::size_t>::max()};
       break;
-    case NArgsPattern::AtLeastOne:
+    case nargs_pattern::at_least_one:
       m_num_args_range = SizeRange{1, std::numeric_limits<std::size_t>::max()};
       break;
     }
@@ -522,7 +522,7 @@ public:
 
   Argument &remaining() {
     m_accepts_optional_like_value = true;
-    return nargs(NArgsPattern::Any);
+    return nargs(nargs_pattern::any);
   }
 
   template <typename Iterator>

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -553,46 +553,19 @@ public:
     if (mIsOptional) {
       if (mIsUsed && !mNumArgsRange.contains(mValues.size()) && !mIsRepeatable &&
           !mDefaultValue.has_value()) {
-        std::stringstream stream;
-        stream << mUsedName << ": expected ";
-        if (mNumArgsRange.is_exact()) {
-          stream << mNumArgsRange.get_min();
-        } else if (mNumArgsRange.is_right_bounded()) {
-          stream << mNumArgsRange.get_min() << " to " << mNumArgsRange.get_max();
-        } else {
-          stream << mNumArgsRange.get_min() << " or more";
-        }
-        stream << " argument(s). "
-          << mValues.size() << " provided.";
-        throw std::runtime_error(stream.str());
+        throw_nargs_range_validation_error();
       } else {
         // TODO: check if an implicit value was programmed for this argument
         if (!mIsUsed && !mDefaultValue.has_value() && mIsRequired) {
-          std::stringstream stream;
-          stream << mNames[0] << ": required.";
-          throw std::runtime_error(stream.str());
+          throw_required_arg_not_used_error();
         }
         if (mIsUsed && mIsRequired && mValues.size() == 0) {
-          std::stringstream stream;
-          stream << mUsedName << ": no value provided.";
-          throw std::runtime_error(stream.str());
+          throw_required_arg_no_value_provided_error();
         }
       }
     } else {
       if (!mNumArgsRange.contains(mValues.size()) && !mDefaultValue.has_value()) {
-        std::stringstream stream;
-        if (!mUsedName.empty())
-          stream << mUsedName << ": ";
-        if (mNumArgsRange.is_exact()) {
-          stream << mNumArgsRange.get_min();
-        } else if (mNumArgsRange.is_right_bounded()) {
-          stream << mNumArgsRange.get_min() << " to " << mNumArgsRange.get_max();
-        } else {
-          stream << mNumArgsRange.get_min() << " or more";
-        }
-        stream << " argument(s) expected. " << mValues.size()
-                << " provided.";
-        throw std::runtime_error(stream.str());
+        throw_nargs_range_validation_error();
       }
     }
   }
@@ -646,6 +619,35 @@ public:
   }
 
 private:
+
+  void throw_nargs_range_validation_error() const {
+    std::stringstream stream;
+    if (!mUsedName.empty())
+      stream << mUsedName << ": ";
+    if (mNumArgsRange.is_exact()) {
+      stream << mNumArgsRange.get_min();
+    } else if (mNumArgsRange.is_right_bounded()) {
+      stream << mNumArgsRange.get_min() << " to " << mNumArgsRange.get_max();
+    } else {
+      stream << mNumArgsRange.get_min() << " or more";
+    }
+    stream << " argument(s) expected. "
+      << mValues.size() << " provided.";
+    throw std::runtime_error(stream.str());
+  }
+
+  void throw_required_arg_not_used_error() const {
+    std::stringstream stream;
+    stream << mNames[0] << ": required.";
+    throw std::runtime_error(stream.str());
+  }
+
+  void throw_required_arg_no_value_provided_error() const {
+    std::stringstream stream;
+    stream << mUsedName << ": no value provided.";
+    throw std::runtime_error(stream.str());
+  }
+
   static constexpr int eof = std::char_traits<char>::eof();
 
   static auto lookahead(std::string_view s) -> int {

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -584,17 +584,12 @@ public:
    */
   void validate() const {
     if (m_is_optional) {
-      if (m_is_used && !m_num_args_range.contains(m_values.size()) && !m_is_repeatable &&
-          !m_default_value.has_value()) {
-        throw_nargs_range_validation_error();
-      } else {
-        // TODO: check if an implicit value was programmed for this argument
-        if (!m_is_used && !m_default_value.has_value() && m_is_required) {
-          throw_required_arg_not_used_error();
-        }
-        if (m_is_used && m_is_required && m_values.size() == 0) {
-          throw_required_arg_no_value_provided_error();
-        }
+      // TODO: check if an implicit value was programmed for this argument
+      if (!m_is_used && !m_default_value.has_value() && m_is_required) {
+        throw_required_arg_not_used_error();
+      }
+      if (m_is_used && m_is_required && m_values.size() == 0) {
+        throw_required_arg_no_value_provided_error();
       }
     } else {
       if (!m_num_args_range.contains(m_values.size()) && !m_default_value.has_value()) {

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -347,9 +347,9 @@ public:
 };
 
 enum class NArgsPattern {
-  ZERO_OR_ONE,
-  ANY,
-  AT_LEAST_ONE
+  ZeroOrOne,
+  Any,
+  AtLeastOne
 };
 
 class ArgumentParser;
@@ -477,13 +477,13 @@ public:
 
   Argument &nargs(NArgsPattern aNargs) {
     switch (aNargs) {
-    case NArgsPattern::ZERO_OR_ONE:
+    case NArgsPattern::ZeroOrOne:
       mNumArgsRange = SizeRange{0, 1};
       break;
-    case NArgsPattern::ANY:
+    case NArgsPattern::Any:
       mNumArgsRange = SizeRange{0, std::numeric_limits<std::size_t>::max()};
       break;
-    case NArgsPattern::AT_LEAST_ONE:
+    case NArgsPattern::AtLeastOne:
       mNumArgsRange = SizeRange{1, std::numeric_limits<std::size_t>::max()};
       break;
     }
@@ -492,7 +492,7 @@ public:
 
   Argument &remaining() {
     mAcceptsOptionalLikeValue = true;
-    return nargs(NArgsPattern::ANY);
+    return nargs(NArgsPattern::Any);
   }
 
   template <typename Iterator>

--- a/test/test_actions.cpp
+++ b/test/test_actions.cpp
@@ -126,7 +126,7 @@ TEST_CASE("Users can use actions on nargs=ANY arguments" *
   argparse::ArgumentParser program("sum");
 
   int result = 0;
-  program.add_argument("all").nargs(argparse::NArgsPattern::ANY).action(
+  program.add_argument("all").nargs(argparse::NArgsPattern::Any).action(
       [](int &sum, std::string const &value) { sum += std::stoi(value); },
       std::ref(result));
 

--- a/test/test_actions.cpp
+++ b/test/test_actions.cpp
@@ -126,7 +126,7 @@ TEST_CASE("Users can use actions on nargs=ANY arguments" *
   argparse::ArgumentParser program("sum");
 
   int result = 0;
-  program.add_argument("all").nargs(argparse::NArgsPattern::Any).action(
+  program.add_argument("all").nargs(argparse::nargs_pattern::any).action(
       [](int &sum, std::string const &value) { sum += std::stoi(value); },
       std::ref(result));
 

--- a/test/test_actions.cpp
+++ b/test/test_actions.cpp
@@ -121,12 +121,12 @@ TEST_CASE("Users can bind arguments to actions" * test_suite("actions")) {
   }
 }
 
-TEST_CASE("Users can use actions on remaining arguments" *
+TEST_CASE("Users can use actions on nargs=ANY arguments" *
           test_suite("actions")) {
   argparse::ArgumentParser program("sum");
 
   int result = 0;
-  program.add_argument("all").remaining().action(
+  program.add_argument("all").nargs(argparse::NArgsPattern::ANY).action(
       [](int &sum, std::string const &value) { sum += std::stoi(value); },
       std::ref(result));
 

--- a/test/test_actions.cpp
+++ b/test/test_actions.cpp
@@ -133,3 +133,16 @@ TEST_CASE("Users can use actions on nargs=ANY arguments" *
   program.parse_args({"sum", "42", "100", "-3", "-20"});
   REQUIRE(result == 119);
 }
+
+TEST_CASE("Users can use actions on remaining arguments" *
+          test_suite("actions")) {
+  argparse::ArgumentParser program("concat");
+
+  std::string result = "";
+  program.add_argument("all").remaining().action(
+      [](std::string &sum, std::string const &value) { sum += value; },
+      std::ref(result));
+
+  program.parse_args({"concat", "a", "-b", "-c", "--d"});
+  REQUIRE(result == "a-b-c--d");
+}

--- a/test/test_actions.cpp
+++ b/test/test_actions.cpp
@@ -140,7 +140,7 @@ TEST_CASE("Users can use actions on remaining arguments" *
 
   std::string result = "";
   program.add_argument("all").remaining().action(
-      [](std::string &sum, std::string const &value) { sum += value; },
+      [](std::string &sum, const std::string &value) { sum += value; },
       std::ref(result));
 
   program.parse_args({"concat", "a", "-b", "-c", "--d"});

--- a/test/test_optional_arguments.cpp
+++ b/test/test_optional_arguments.cpp
@@ -88,7 +88,7 @@ TEST_CASE("Parse optional arguments of many values" *
     program.add_argument("-i").remaining().scan<'i', int>();
 
     WHEN("provided no argument") {
-      THEN("the program accepts it bug gets nothing") {
+      THEN("the program accepts it but gets nothing") {
         REQUIRE_NOTHROW(program.parse_args({"test"}));
         REQUIRE_THROWS_AS(program.get<std::vector<int>>("-i"),
                           std::logic_error);

--- a/test/test_optional_arguments.cpp
+++ b/test/test_optional_arguments.cpp
@@ -110,6 +110,86 @@ TEST_CASE("Parse optional arguments of many values" *
   }
 }
 
+TEST_CASE("Parse 2 optional arguments of many values" *
+          test_suite("optional_arguments")) {
+  GIVEN("a program that accepts 2 optional arguments of many values") {
+    argparse::ArgumentParser program("test");
+    program.add_argument("-i").nargs(argparse::NArgsPattern::ANY).scan<'i', int>();
+    program.add_argument("-s").nargs(argparse::NArgsPattern::ANY);
+
+    WHEN("provided no argument") {
+      THEN("the program accepts it and gets empty container") {
+        REQUIRE_NOTHROW(program.parse_args({"test"}));
+        auto i = program.get<std::vector<int>>("-i");
+        REQUIRE(i.size() == 0);
+
+        auto s = program.get<std::vector<std::string>>("-s");
+        REQUIRE(s.size() == 0);
+      }
+    }
+
+    WHEN("provided 2 options with many arguments") {
+      program.parse_args(
+        {"test", "-i", "-42", "8", "100", "300", "-s", "ok", "this", "works"});
+
+      THEN("the optional parameter consumes each arguments") {
+        auto i = program.get<std::vector<int>>("-i");
+        REQUIRE(i.size() == 4);
+        REQUIRE(i[0] == -42);
+        REQUIRE(i[1] == 8);
+        REQUIRE(i[2] == 100);
+        REQUIRE(i[3] == 300);
+
+        auto s = program.get<std::vector<std::string>>("-s");
+        REQUIRE(s.size() == 3);
+        REQUIRE(s[0] == "ok");
+        REQUIRE(s[1] == "this");
+        REQUIRE(s[2] == "works");
+      }
+    }
+  }
+}
+
+TEST_CASE("Parse an optional argument of many values"
+          " and a positional argument of many values" *
+          test_suite("optional_arguments")) {
+  GIVEN("a program that accepts an optional argument of many values"
+        " and a positional argument of many values") {
+    argparse::ArgumentParser program("test");
+    program.add_argument("-s").nargs(argparse::NArgsPattern::ANY);
+    program.add_argument("input").nargs(argparse::NArgsPattern::ANY);
+
+    WHEN("provided no argument") {
+      program.parse_args({"test"});
+      THEN("the program accepts it and gets empty containers") {
+        auto s = program.get<std::vector<std::string>>("-s");
+        REQUIRE(s.size() == 0);
+
+        auto input = program.get<std::vector<std::string>>("input");
+        REQUIRE(input.size() == 0);
+      }
+    }
+
+    WHEN("provided many arguments followed by an option with many arguments") {
+      program.parse_args(
+        {"test", "foo", "bar", "-s", "ok", "this", "works"});
+
+      THEN("the parameters consume each arguments") {
+        auto s = program.get<std::vector<std::string>>("-s");
+        REQUIRE(s.size() == 3);
+        REQUIRE(s[0] == "ok");
+        REQUIRE(s[1] == "this");
+        REQUIRE(s[2] == "works");
+
+        auto input = program.get<std::vector<std::string>>("input");
+        REQUIRE(input.size() == 2);
+        REQUIRE(input[0] == "foo");
+        REQUIRE(input[1] == "bar");
+      }
+    }
+  }
+}
+
 TEST_CASE("Parse arguments of different types" *
           test_suite("optional_arguments")) {
   using namespace std::literals;

--- a/test/test_optional_arguments.cpp
+++ b/test/test_optional_arguments.cpp
@@ -114,8 +114,8 @@ TEST_CASE("Parse 2 optional arguments of many values" *
           test_suite("optional_arguments")) {
   GIVEN("a program that accepts 2 optional arguments of many values") {
     argparse::ArgumentParser program("test");
-    program.add_argument("-i").nargs(argparse::NArgsPattern::ANY).scan<'i', int>();
-    program.add_argument("-s").nargs(argparse::NArgsPattern::ANY);
+    program.add_argument("-i").nargs(argparse::NArgsPattern::Any).scan<'i', int>();
+    program.add_argument("-s").nargs(argparse::NArgsPattern::Any);
 
     WHEN("provided no argument") {
       THEN("the program accepts it and gets empty container") {
@@ -156,8 +156,8 @@ TEST_CASE("Parse an optional argument of many values"
   GIVEN("a program that accepts an optional argument of many values"
         " and a positional argument of many values") {
     argparse::ArgumentParser program("test");
-    program.add_argument("-s").nargs(argparse::NArgsPattern::ANY);
-    program.add_argument("input").nargs(argparse::NArgsPattern::ANY);
+    program.add_argument("-s").nargs(argparse::NArgsPattern::Any);
+    program.add_argument("input").nargs(argparse::NArgsPattern::Any);
 
     WHEN("provided no argument") {
       program.parse_args({"test"});

--- a/test/test_optional_arguments.cpp
+++ b/test/test_optional_arguments.cpp
@@ -88,10 +88,10 @@ TEST_CASE("Parse optional arguments of many values" *
     program.add_argument("-i").remaining().scan<'i', int>();
 
     WHEN("provided no argument") {
-      THEN("the program accepts it but gets nothing") {
+      THEN("the program accepts it and gets empty container") {
         REQUIRE_NOTHROW(program.parse_args({"test"}));
-        REQUIRE_THROWS_AS(program.get<std::vector<int>>("-i"),
-                          std::logic_error);
+        auto inputs = program.get<std::vector<int>>("-i");
+        REQUIRE(inputs.size() == 0);
       }
     }
 

--- a/test/test_optional_arguments.cpp
+++ b/test/test_optional_arguments.cpp
@@ -88,10 +88,10 @@ TEST_CASE("Parse optional arguments of many values" *
     program.add_argument("-i").remaining().scan<'i', int>();
 
     WHEN("provided no argument") {
-      THEN("the program accepts it and gets empty container") {
+      THEN("the program accepts it bug gets nothing") {
         REQUIRE_NOTHROW(program.parse_args({"test"}));
-        auto inputs = program.get<std::vector<int>>("-i");
-        REQUIRE(inputs.size() == 0);
+        REQUIRE_THROWS_AS(program.get<std::vector<int>>("-i"),
+                          std::logic_error);
       }
     }
 

--- a/test/test_optional_arguments.cpp
+++ b/test/test_optional_arguments.cpp
@@ -114,8 +114,8 @@ TEST_CASE("Parse 2 optional arguments of many values" *
           test_suite("optional_arguments")) {
   GIVEN("a program that accepts 2 optional arguments of many values") {
     argparse::ArgumentParser program("test");
-    program.add_argument("-i").nargs(argparse::NArgsPattern::Any).scan<'i', int>();
-    program.add_argument("-s").nargs(argparse::NArgsPattern::Any);
+    program.add_argument("-i").nargs(argparse::nargs_pattern::any).scan<'i', int>();
+    program.add_argument("-s").nargs(argparse::nargs_pattern::any);
 
     WHEN("provided no argument") {
       THEN("the program accepts it and gets empty container") {
@@ -156,8 +156,8 @@ TEST_CASE("Parse an optional argument of many values"
   GIVEN("a program that accepts an optional argument of many values"
         " and a positional argument of many values") {
     argparse::ArgumentParser program("test");
-    program.add_argument("-s").nargs(argparse::NArgsPattern::Any);
-    program.add_argument("input").nargs(argparse::NArgsPattern::Any);
+    program.add_argument("-s").nargs(argparse::nargs_pattern::any);
+    program.add_argument("input").nargs(argparse::nargs_pattern::any);
 
     WHEN("provided no argument") {
       program.parse_args({"test"});

--- a/test/test_positional_arguments.cpp
+++ b/test/test_positional_arguments.cpp
@@ -234,6 +234,12 @@ TEST_CASE("Parse remaining arguments deemed positional" *
   }
 }
 
+TEST_CASE("Reversed order nargs is not allowed" *
+          test_suite("positional_arguments")) {
+  argparse::ArgumentParser program("test");
+  REQUIRE_THROWS_AS(program.add_argument("output").nargs(2, 1), std::logic_error);
+}
+
 TEST_CASE("Square a number" * test_suite("positional_arguments")) {
   argparse::ArgumentParser program;
   program.add_argument("--verbose", "-v")

--- a/test/test_positional_arguments.cpp
+++ b/test/test_positional_arguments.cpp
@@ -142,7 +142,7 @@ TEST_CASE("Parse positional nargs=ANY arguments" *
   GIVEN("a program that accepts an optional argument and nargs=ANY positional arguments") {
     argparse::ArgumentParser program("test");
     program.add_argument("-o");
-    program.add_argument("input").nargs(argparse::NArgsPattern::Any);
+    program.add_argument("input").nargs(argparse::nargs_pattern::any);
 
     WHEN("provided no argument") {
       THEN("the program accepts it and gets empty container") {

--- a/test/test_positional_arguments.cpp
+++ b/test/test_positional_arguments.cpp
@@ -61,6 +61,130 @@ TEST_CASE("Parse positional arguments with optional arguments in the middle" *
   REQUIRE_THROWS(program.parse_args({ "test", "rocket.mesh", "thrust_profile.csv", "--num_iterations", "15", "output.mesh" }));
 }
 
+TEST_CASE("Parse positional nargs=1..2 arguments" *
+          test_suite("positional_arguments")) {
+  GIVEN("a program that accepts an optional argument and nargs=1..2 positional arguments") {
+    argparse::ArgumentParser program("test");
+    program.add_argument("-o");
+    program.add_argument("input").nargs(1, 2);
+
+    WHEN("provided no argument") {
+      THEN("the program does not accept it") {
+        REQUIRE_THROWS(program.parse_args({"test"}));
+      }
+    }
+
+    WHEN("provided 1 argument") {
+      THEN("the program accepts it") {
+        REQUIRE_NOTHROW(program.parse_args({"test", "a.c"}));
+
+        auto inputs = program.get<std::vector<std::string>>("input");
+        REQUIRE(inputs.size() == 1);
+        REQUIRE(inputs[0] == "a.c");
+      }
+    }
+
+    WHEN("provided 2 arguments") {
+      THEN("the program accepts it") {
+        REQUIRE_NOTHROW(program.parse_args({"test", "a.c", "b.c"}));
+
+        auto inputs = program.get<std::vector<std::string>>("input");
+        REQUIRE(inputs.size() == 2);
+        REQUIRE(inputs[0] == "a.c");
+        REQUIRE(inputs[1] == "b.c");
+      }
+    }
+
+    WHEN("provided 3 arguments") {
+      THEN("the program does not accept it") {
+        REQUIRE_THROWS(program.parse_args({"test", "a.c", "b.c", "main.c"}));
+      }
+    }
+
+    WHEN("provided an optional followed by positional arguments") {
+      program.parse_args({"test", "-o", "a.out", "a.c", "b.c"});
+
+      THEN("the optional parameter consumes an argument") {
+        using namespace std::literals;
+        REQUIRE(program["-o"] == "a.out"s);
+
+        auto inputs = program.get<std::vector<std::string>>("input");
+        REQUIRE(inputs.size() == 2);
+        REQUIRE(inputs[0] == "a.c");
+        REQUIRE(inputs[1] == "b.c");
+      }
+    }
+
+    WHEN("provided an optional preceded by positional arguments") {
+      program.parse_args({"test", "a.c", "b.c", "-o", "a.out"});
+
+      THEN("the optional parameter consumes an argument") {
+        using namespace std::literals;
+        REQUIRE(program["-o"] == "a.out"s);
+
+        auto inputs = program.get<std::vector<std::string>>("input");
+        REQUIRE(inputs.size() == 2);
+        REQUIRE(inputs[0] == "a.c");
+        REQUIRE(inputs[1] == "b.c");
+      }
+    }
+
+    WHEN("provided an optional in between positional arguments") {
+      THEN("the program does not accept it") {
+        REQUIRE_THROWS(program.parse_args({"test", "a.c", "-o", "a.out", "b.c"}));
+      }
+    }
+  }
+}
+
+TEST_CASE("Parse positional nargs=ANY arguments" *
+          test_suite("positional_arguments")) {
+  GIVEN("a program that accepts an optional argument and nargs=ANY positional arguments") {
+    argparse::ArgumentParser program("test");
+    program.add_argument("-o");
+    program.add_argument("input").nargs(argparse::NArgsPattern::ANY);
+
+    WHEN("provided no argument") {
+      THEN("the program accepts it and gets empty container") {
+        REQUIRE_NOTHROW(program.parse_args({"test"}));
+
+        auto inputs = program.get<std::vector<std::string>>("input");
+        REQUIRE(inputs.size() == 0);
+      }
+    }
+
+    WHEN("provided an optional followed by positional arguments") {
+      program.parse_args({"test", "-o", "a.out", "a.c", "b.c", "main.c"});
+
+      THEN("the optional parameter consumes an argument") {
+        using namespace std::literals;
+        REQUIRE(program["-o"] == "a.out"s);
+
+        auto inputs = program.get<std::vector<std::string>>("input");
+        REQUIRE(inputs.size() == 3);
+        REQUIRE(inputs[0] == "a.c");
+        REQUIRE(inputs[1] == "b.c");
+        REQUIRE(inputs[2] == "main.c");
+      }
+    }
+
+    WHEN("provided an optional preceded by positional arguments") {
+      program.parse_args({"test", "a.c", "b.c", "main.c", "-o", "a.out"});
+
+      THEN("the optional parameter consumes an argument") {
+        using namespace std::literals;
+        REQUIRE(program["-o"] == "a.out"s);
+
+        auto inputs = program.get<std::vector<std::string>>("input");
+        REQUIRE(inputs.size() == 3);
+        REQUIRE(inputs[0] == "a.c");
+        REQUIRE(inputs[1] == "b.c");
+        REQUIRE(inputs[2] == "main.c");
+      }
+    }
+  }
+}
+
 TEST_CASE("Parse remaining arguments deemed positional" *
           test_suite("positional_arguments")) {
   GIVEN("a program that accepts an optional argument and remaining arguments") {

--- a/test/test_positional_arguments.cpp
+++ b/test/test_positional_arguments.cpp
@@ -109,12 +109,6 @@ TEST_CASE("Parse remaining arguments deemed positional" *
   }
 }
 
-TEST_CASE("Negative nargs is not allowed" *
-          test_suite("positional_arguments")) {
-  argparse::ArgumentParser program("test");
-  REQUIRE_THROWS_AS(program.add_argument("output").nargs(-1), std::logic_error);
-}
-
 TEST_CASE("Square a number" * test_suite("positional_arguments")) {
   argparse::ArgumentParser program;
   program.add_argument("--verbose", "-v")

--- a/test/test_positional_arguments.cpp
+++ b/test/test_positional_arguments.cpp
@@ -193,11 +193,10 @@ TEST_CASE("Parse remaining arguments deemed positional" *
     program.add_argument("input").remaining();
 
     WHEN("provided no argument") {
-      THEN("the program accepts it and gets empty container") {
+      THEN("the program accepts it but gets nothing") {
         REQUIRE_NOTHROW(program.parse_args({"test"}));
-
-        auto inputs = program.get<std::vector<std::string>>("input");
-        REQUIRE(inputs.size() == 0);
+        REQUIRE_THROWS_AS(program.get<std::vector<std::string>>("input"),
+                          std::logic_error);
       }
     }
 

--- a/test/test_positional_arguments.cpp
+++ b/test/test_positional_arguments.cpp
@@ -69,10 +69,11 @@ TEST_CASE("Parse remaining arguments deemed positional" *
     program.add_argument("input").remaining();
 
     WHEN("provided no argument") {
-      THEN("the program accepts it but gets nothing") {
+      THEN("the program accepts it and gets empty container") {
         REQUIRE_NOTHROW(program.parse_args({"test"}));
-        REQUIRE_THROWS_AS(program.get<std::vector<std::string>>("input"),
-                          std::logic_error);
+
+        auto inputs = program.get<std::vector<std::string>>("input");
+        REQUIRE(inputs.size() == 0);
       }
     }
 

--- a/test/test_positional_arguments.cpp
+++ b/test/test_positional_arguments.cpp
@@ -142,7 +142,7 @@ TEST_CASE("Parse positional nargs=ANY arguments" *
   GIVEN("a program that accepts an optional argument and nargs=ANY positional arguments") {
     argparse::ArgumentParser program("test");
     program.add_argument("-o");
-    program.add_argument("input").nargs(argparse::NArgsPattern::ANY);
+    program.add_argument("input").nargs(argparse::NArgsPattern::Any);
 
     WHEN("provided no argument") {
       THEN("the program accepts it and gets empty container") {


### PR DESCRIPTION
Hi.
Thank you for this nice library.

I see some issues regarding "remaining" behavior.

https://github.com/p-ranav/argparse/issues/118
https://github.com/p-ranav/argparse/issues/81

I also wanted optional argument preceded by variable length positional arguments (including zero length) like Python argparse nargs "*", "+", "?"

So, I implemented it just for experiment.
For now, this worked for me.

I know this change drops "remaining" feature, which would impact existing projects.
Also, this seems a complicated problem and I think more study may be needed.

What do you think about this change?

Thank you in advance.