### PR TITLE
Make get syntax flexible

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -960,7 +960,7 @@ public:
         return *(tIterator->second);
       }
     }
-    throw std::logic_error("No such argument");
+    throw std::logic_error("No such argument: " + std::string(aArgumentName));
   }
 
   // Print help message

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -945,6 +945,21 @@ public:
     if (tIterator != mArgumentMap.end()) {
       return *(tIterator->second);
     }
+    if (aArgumentName.front() != '-') {
+      std::string nameStr(aArgumentName);
+      // "-" + aArgumentName
+      nameStr = "-" + nameStr;
+      tIterator = mArgumentMap.find(nameStr);
+      if (tIterator != mArgumentMap.end()) {
+        return *(tIterator->second);
+      }
+      // "--" + aArgumentName
+      nameStr = "-" + nameStr;
+      tIterator = mArgumentMap.find(nameStr);
+      if (tIterator != mArgumentMap.end()) {
+        return *(tIterator->second);
+      }
+    }
     throw std::logic_error("No such argument");
   }
 


### PR DESCRIPTION
As mentioned in https://github.com/p-ranav/argparse/issues/87, I also think it'd better that get("out") is also available to "--out" option, for example.

Actually, I made this kind of mistake many times because with Python argparse, this syntax is OK.

In this pull request, I made get syntax more flexible this way.

Additionally, now thrown logic_error.what() kindly shows what argument is invalid to make debug easier.