### PR TITLE
Add CMake project name

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.6)
+project(argparse)
 
 if(MSVC)
   # Force to always compile with W4


### PR DESCRIPTION
This silences the following warning:

  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.

Signed-off-by: Sean Robinson <sean.robinson@scottsdalecc.edu>