### PR TITLE
Improve thrown message in case of invalid argument.

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -1089,11 +1089,11 @@ private:
             auto tArgument = tIterator2->second;
             it = tArgument->consume(it, end, tIterator2->first);
           } else {
-            throw std::runtime_error("Unknown argument");
+            throw std::runtime_error("Unknown argument: " + tCurrentArgument);
           }
         }
       } else {
-        throw std::runtime_error("Unknown argument");
+        throw std::runtime_error("Unknown argument: " + tCurrentArgument);
       }
     }
     mIsParsed = true;

--- a/test/test_invalid_arguments.cpp
+++ b/test/test_invalid_arguments.cpp
@@ -36,5 +36,6 @@ TEST_CASE("Parse unknown optional argument" *
     .scan<'u', unsigned long long>()
     .help("memory in MB to give the VMM when loading");
 
-  REQUIRE_THROWS(bfm.parse_args({ "./test.exe", "-om" }));
+  REQUIRE_THROWS_WITH_AS(bfm.parse_args({"./test.exe", "-om"}),
+                         "Unknown argument: -om", std::runtime_error);
 }

--- a/test/test_version.cpp
+++ b/test/test_version.cpp
@@ -16,8 +16,8 @@ TEST_CASE("Users can print version and exit" * test_suite("version")
 TEST_CASE("Users can disable default -v/--version" * test_suite("version")) {
   argparse::ArgumentParser program("test", "1.0",
                                    argparse::default_arguments::help);
-  REQUIRE_THROWS_AS(program.parse_args({"test", "--version"}),
-                    std::runtime_error);
+  REQUIRE_THROWS_WITH_AS(program.parse_args({"test", "--version"}),
+                         "Unknown argument: --version", std::runtime_error);
 }
 
 TEST_CASE("Users can replace default -v/--version" * test_suite("version")) {


### PR DESCRIPTION
Now message contains information which argument is the source of error.
It's easier to spot typo/understand which part of more complex command
is the source of problem.