### PR TITLE
Fix regression in version printing.

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -867,7 +867,7 @@ public:
     if ((add_args & default_arguments::version) == default_arguments::version) {
       add_argument("-v", "--version")
           .action([&](const auto &unused) {
-            std::cout << m_version;
+            std::cout << m_version << std::endl;
             std::exit(0);
           })
           .default_value(false)


### PR DESCRIPTION
This regression was caused by commit
ea1f7ef663899e799001f50055cc93c733a9fff, which didn't add "\n" to the
version printing statement. We use std::endl now for compatibility
across platforms.