### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ If you want to know whether the user supplied a value for an argument that has a
 
 ```cpp
 program.add_argument("--color")
-  .default_value("orange")
+  .default_value(std::string{"orange"})   // might otherwise be type const char* leading to an error when trying program.get<std::string>
   .help("specify the cat's fur color");
 
 try {


### PR DESCRIPTION
Fixed the example in section" #### Deciding if the value was given by the user".
Issue [1] already clarifies the problem with type deduction: Using
`program.add_argument("--topic") .default_value("some default value");`
leads to type `const char *` instead of std::string, which then causes an error when trying to readout the value using
`auto topic = arg.get<std::string>("--topic");` instead of `auto topic = arg.get<const char*>("--topic");` Therefore changed the example to make it work.
[1] https://github.com/p-ranav/argparse/issues/96
PS: Thanks for this great work :)