### PR TITLE
Fix remaining unused argument warnings.

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -349,7 +349,7 @@ class Argument {
 
   template <std::size_t N, std::size_t... I>
   explicit Argument(std::array<std::string_view, N> &&a,
-                    std::index_sequence<I...> unused)
+                    std::index_sequence<I...> /*unused*/)
       : m_is_optional((is_optional(a[I]) || ...)), m_is_required(false),
         m_is_repeatable(false), m_is_used(false) {
     ((void)m_names.emplace_back(a[I]), ...);


### PR DESCRIPTION
Commit 5c5c55b83cc7d542890a47aeee6530a8ee6d10f7 missed one such
occurrence.