### PR TITLE
Allow --option=value form of arguments

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -1172,7 +1172,32 @@ private:
   /*
    * @throws std::runtime_error in case of any invalid argument
    */
-  void parse_args_internal(const std::vector<std::string> &arguments) {
+  void parse_args_internal(const std::vector<std::string> &raw_arguments) {
+    // Pre-process this argument list. Anything starting with "--", that
+    // contains an =, where the prefix before the = has an entry in the
+    // options table, should be split.
+    std::vector<std::string> arguments;
+    for (const auto &arg : raw_arguments) {
+      // Check that:
+      // - We don't have an argument named exactly this
+      // - The argument starts with "--"
+      // - The argument contains a "="
+      std::size_t eqpos = arg.find("=");
+      if (m_argument_map.find(arg) == m_argument_map.end() &&
+          arg.rfind("--", 0) == 0 && eqpos != std::string::npos) {
+        // Get the name of the potential option, and check it exists
+        std::string opt_name = arg.substr(0, eqpos);
+        if (m_argument_map.find(opt_name) != m_argument_map.end()) {
+          // This is the name of an option! Split it into two parts
+          arguments.push_back(std::move(opt_name));
+          arguments.push_back(arg.substr(eqpos + 1));
+          continue;
+        }
+      }
+      // If we've fallen through to here, then it's a standard argument
+      arguments.push_back(arg);
+    }
+
     if (m_program_name.empty() && !arguments.empty()) {
       m_program_name = arguments.front();
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,7 @@ file(GLOB ARGPARSE_TEST_SOURCES
     test_scan.cpp
     test_value_semantics.cpp
     test_version.cpp
+    test_equals_form.cpp
 )
 set_source_files_properties(main.cpp
     PROPERTIES

--- a/test/test_equals_form.cpp
+++ b/test/test_equals_form.cpp
@@ -1,0 +1,31 @@
+#include <argparse/argparse.hpp>
+#include <doctest.hpp>
+#include <iostream>
+using doctest::test_suite;
+
+TEST_CASE("Basic --value=value" * test_suite("equals_form")) {
+  argparse::ArgumentParser parser("test");
+  parser.add_argument("--long");
+  parser.parse_args({"test", "--long=value"});
+  std::string result{parser.get("--long")};
+  REQUIRE(result == "value");
+}
+
+TEST_CASE("Fallback = in regular option name" * test_suite("equals_form")) {
+  argparse::ArgumentParser parser("test");
+  parser.add_argument("--long=mislead");
+  parser.parse_args({"test", "--long=mislead", "value"});
+  std::string result{parser.get("--long=mislead")};
+  REQUIRE(result == "value");
+}
+
+TEST_CASE("Duplicate =-named and standard" * test_suite("equals_form")) {
+  argparse::ArgumentParser parser("test");
+  parser.add_argument("--long=mislead");
+  parser.add_argument("--long").default_value(std::string{"NO_VALUE"});
+  parser.parse_args({"test", "--long=mislead", "value"});
+  std::string result{parser.get("--long=mislead")};
+  REQUIRE(result == "value");
+  std::string result2{parser.get("--long")};
+  REQUIRE(result2 == "NO_VALUE");
+}


### PR DESCRIPTION
So that you can pass long options as `./test --option=value` in addition to the currently supported `./test --option value`. This is done by simply pre-parsing the argument list and splitting up any arguments that:
- Appear to be in the form `--option=`
- The "--option" part before the = is in the argument map (e.g. it's recognised)
- Are not present as a full "--option=value" option in the argument map

This latter is required because it's currently valid to have a full named option that includes "=" as part of its proper name. I've tried to be somewhat defensive on the tests to allow this existing use case.

This is somewhat requested as part of https://github.com/p-ranav/argparse/issues/67, though doesn't go as far as that issue suggests. The approach in this PR will work with multiple-argument options because of the rewrite, but it might not make complete sense to people expecting the more usual approach, which doesn't normally allow multiple arguments to an `--longname` option at all.