### PR TITLE
Rework/Enhance help and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,15 +303,15 @@ The square of 4 is 16
 
 ```
 $ ./main --help
-Usage: main [options] square
+Usage: main [-h] [--verbose] square
 
 Positional arguments:
-square          display the square of a given number
+  square       	display the square of a given number
 
 Optional arguments:
--h --help       shows help message and exits [default: false]
--v --version    prints version information and exits [default: false]
---verbose       [default: false]
+  -h, --help   	shows help message and exits
+  -v, --version	prints version information and exits
+  --verbose
 ```
 
 You may also get the help message in string via `program.help().str()`.
@@ -336,16 +336,16 @@ std::cout << program << std::endl;
 
 ```bash
 $ ./main --help
-Usage: main thing
+Usage: main [-h] thing
 
 Forward a thing to the next member.
 
 Positional arguments:
-thing           Thing to use.
+  thing        	Thing to use.
 
 Optional arguments:
--h --help       shows help message and exits [default: false]
--v --version    prints version information and exits [default: false]
+  -h, --help   	shows help message and exits
+  -v, --version	prints version information and exits
 
 Possible things include betingalw, chiz, and res.
 ```

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -377,6 +377,11 @@ public:
     return *this;
   }
 
+  Argument &metavar(std::string metavar) {
+    m_metavar = std::move(metavar);
+    return *this;
+  }
+
   template <typename T> Argument &default_value(T &&value) {
     m_default_value_repr = details::repr(value);
     m_default_value = std::forward<T>(value);
@@ -565,11 +570,15 @@ public:
   }
 
   std::size_t get_arguments_length() const {
-    return std::accumulate(std::begin(m_names), std::end(m_names),
+    std::size_t size = std::accumulate(std::begin(m_names), std::end(m_names),
                            std::size_t(0), [](const auto &sum, const auto &s) {
                              return sum + s.size() +
                                     1; // +1 for space between names
                            });
+    if (!m_metavar.empty()) {
+      size += m_metavar.size() + 1;
+    }
+    return size;
   }
 
   friend std::ostream &operator<<(std::ostream &stream,
@@ -577,6 +586,9 @@ public:
     std::stringstream name_stream;
     std::copy(std::begin(argument.m_names), std::end(argument.m_names),
               std::ostream_iterator<std::string>(name_stream, " "));
+    if(!argument.m_metavar.empty() && argument.m_num_args_range.get_min() != 0) {
+      name_stream << argument.m_metavar << " ";
+    }
     stream << name_stream.str() << "\t" << argument.m_help;
     if (argument.m_default_value.has_value()) {
       if (!argument.m_help.empty()) {
@@ -908,6 +920,7 @@ private:
   std::vector<std::string> m_names;
   std::string_view m_used_name;
   std::string m_help;
+  std::string m_metavar;
   std::any m_default_value;
   std::string m_default_value_repr;
   std::any m_implicit_value;


### PR DESCRIPTION
Generally reworked help output to be a little more like what I expect (or, at least, like python's argparse)

- Added metavars. If set, then will be used in help for the value placeholder for options, or the placeholder alone for regular positional arguments.
- Help option sections are indented by two spaces, and comma-separated. They now show metavar (this means that an option with value now shows as `--option VALUE     Description of Option` instead of `--option    Description ...`.
- Usage section now enumerates options, instead of just `[options]`. Added `ArgumentParser::usage()` to retreive this string alone (in case you wanted to, say, print usage if arguments incorrectly passed).
- Not showing `[default: ...]` for implicit values. This seemed unusual. It might be better to rework the help system to recognise a placeholder (even python's `%(default)s`) rather than try to magically get this right.
- I've refreshed the README with the updated strings from this approach.

I guess the biggest holes are:
- Multiple argument support is a little underrepresented compared to the full semantics of python's argparse. I don't know how well the approach to multiple arguments in this package matches the semantics of the python package.
- I haven't written tests for this because the help output doesn't seem to be tested. I'm not opposed to writing some.

Otherwise this... might not be how you want things. If you like these changes I'm happy to do some amount of reworking to get it up to scratch for merging - these changes work for my purposes, but it could be that you wanted all of this done some other way. I thought I'd at least try to polish them up if it was useful ;)

---

A slightly expanded version of the README second example:
```c++
  argparse::ArgumentParser program("main");
  program.add_argument("thing").help("Thing to use.").metavar("THING");
  program.add_argument("--member").help("The alias for the member to pass to.").metavar("ALIAS");
  program.add_argument("--verbose").default_value(false).implicit_value(true);
  program.add_description("Forward a thing to the next member.");
  program.add_epilog("Possible things include betingalw, chiz, and res.");
```
Gives:
```
% ./main --help
Usage: main [-h] [--member ALIAS] [--verbose] THING

Forward a thing to the next member.

Positional arguments:
  THING         	Thing to use.

Optional arguments:
  -h, --help    	shows help message and exits
  -v, --version 	prints version information and exits
  --member ALIAS	The alias for the member to pass to.
  --verbose

Possible things include betingalw, chiz, and res.

```