### PR TITLE
Add fuzzy matching

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -149,8 +149,9 @@ constexpr bool standard_integer =
     standard_signed_integer<T> || standard_unsigned_integer<T>;
 
 template <class F, class Tuple, class Extra, std::size_t... I>
-constexpr decltype(auto) apply_plus_one_impl(F &&f, Tuple &&t, Extra &&x,
-                                             std::index_sequence<I...> /*unused*/) {
+constexpr decltype(auto)
+apply_plus_one_impl(F &&f, Tuple &&t, Extra &&x,
+                    std::index_sequence<I...> /*unused*/) {
   return std::invoke(std::forward<F>(f), std::get<I>(std::forward<Tuple>(t))...,
                      std::forward<Extra>(x));
 }
@@ -328,11 +329,7 @@ template <class T> struct parse_number<T, chars_format::fixed> {
 
 } // namespace details
 
-enum class nargs_pattern {
-  optional,
-  any,
-  at_least_one
-};
+enum class nargs_pattern { optional, any, at_least_one };
 
 enum class default_arguments : unsigned int {
   none = 0,
@@ -429,7 +426,8 @@ public:
 
     if constexpr (is_one_of(Shape, 'd') && details::standard_integer<T>) {
       action(details::parse_number<T, details::radix_10>());
-    } else if constexpr (is_one_of(Shape, 'i') && details::standard_integer<T>) {
+    } else if constexpr (is_one_of(Shape, 'i') &&
+                         details::standard_integer<T>) {
       action(details::parse_number<T>());
     } else if constexpr (is_one_of(Shape, 'u') &&
                          details::standard_unsigned_integer<T>) {
@@ -506,7 +504,8 @@ public:
       std::visit([](const auto &f) { f({}); }, m_action);
       return start;
     }
-    if ((dist = static_cast<std::size_t>(std::distance(start, end))) >= num_args_min) {
+    if ((dist = static_cast<std::size_t>(std::distance(start, end))) >=
+        num_args_min) {
       if (num_args_max < dist) {
         end = std::next(start, num_args_max);
       }
@@ -558,7 +557,8 @@ public:
         throw_required_arg_no_value_provided_error();
       }
     } else {
-      if (!m_num_args_range.contains(m_values.size()) && !m_default_value.has_value()) {
+      if (!m_num_args_range.contains(m_values.size()) &&
+          !m_default_value.has_value()) {
         throw_nargs_range_validation_error();
       }
     }
@@ -606,15 +606,13 @@ public:
       return get<T>() == rhs;
     } else {
       auto lhs = get<T>();
-      return std::equal(std::begin(lhs), std::end(lhs), std::begin(rhs),
-                        std::end(rhs), [](const auto &lhs, const auto &rhs) {
-                          return lhs == rhs;
-                        });
+      return std::equal(
+          std::begin(lhs), std::end(lhs), std::begin(rhs), std::end(rhs),
+          [](const auto &lhs, const auto &rhs) { return lhs == rhs; });
     }
   }
 
 private:
-
   class NArgsRange {
     std::size_t m_min;
     std::size_t m_max;
@@ -631,21 +629,15 @@ private:
       return value >= m_min && value <= m_max;
     }
 
-    bool is_exact() const {
-      return m_min == m_max;
-    }
+    bool is_exact() const { return m_min == m_max; }
 
     bool is_right_bounded() const {
       return m_max < std::numeric_limits<std::size_t>::max();
     }
 
-    std::size_t get_min() const {
-      return m_min;
-    }
+    std::size_t get_min() const { return m_min; }
 
-    std::size_t get_max() const {
-      return m_max;
-    }
+    std::size_t get_max() const { return m_max; }
   };
 
   void throw_nargs_range_validation_error() const {
@@ -656,7 +648,8 @@ private:
     if (m_num_args_range.is_exact()) {
       stream << m_num_args_range.get_min();
     } else if (m_num_args_range.is_right_bounded()) {
-      stream << m_num_args_range.get_min() << " to " << m_num_args_range.get_max();
+      stream << m_num_args_range.get_min() << " to "
+             << m_num_args_range.get_max();
     } else {
       stream << m_num_args_range.get_min() << " or more";
     }
@@ -855,7 +848,9 @@ private:
    * Get argument value given a type
    * @throws std::logic_error in case of incompatible types
    */
-  template <typename T> auto get() const -> std::conditional_t<details::IsContainer<T>, T, const T&> {
+  template <typename T>
+  auto get() const
+      -> std::conditional_t<details::IsContainer<T>, T, const T &> {
     if (!m_values.empty()) {
       if constexpr (details::IsContainer<T>) {
         return any_cast_container<T>(m_values);
@@ -916,7 +911,7 @@ private:
       std::in_place_type<valued_action>,
       [](const std::string &value) { return value; }};
   std::vector<std::any> m_values;
-  NArgsRange m_num_args_range {1, 1};
+  NArgsRange m_num_args_range{1, 1};
   bool m_accepts_optional_like_value = false;
   bool m_is_optional : true;
   bool m_is_required : true;
@@ -932,7 +927,7 @@ public:
       : m_program_name(std::move(program_name)), m_version(std::move(version)) {
     if ((add_args & default_arguments::help) == default_arguments::help) {
       add_argument("-h", "--help")
-          .action([&](const auto &/*unused*/) {
+          .action([&](const auto & /*unused*/) {
             std::cout << help().str();
             std::exit(0);
           })
@@ -943,7 +938,7 @@ public:
     }
     if ((add_args & default_arguments::version) == default_arguments::version) {
       add_argument("-v", "--version")
-          .action([&](const auto &/*unused*/) {
+          .action([&](const auto & /*unused*/) {
             std::cout << m_version << std::endl;
             std::exit(0);
           })
@@ -958,10 +953,8 @@ public:
   ArgumentParser &operator=(ArgumentParser &&) = default;
 
   ArgumentParser(const ArgumentParser &other)
-      : m_program_name(other.m_program_name),
-        m_version(other.m_version),
-        m_description(other.m_description),
-        m_epilog(other.m_epilog),
+      : m_program_name(other.m_program_name), m_version(other.m_version),
+        m_description(other.m_description), m_epilog(other.m_epilog),
         m_is_parsed(other.m_is_parsed),
         m_positional_arguments(other.m_positional_arguments),
         m_optional_arguments(other.m_optional_arguments) {
@@ -1036,7 +1029,7 @@ public:
   void parse_args(const std::vector<std::string> &arguments) {
     parse_args_internal(arguments);
     // Check if all arguments are parsed
-    for ([[maybe_unused]] const auto& [unused, argument] : m_argument_map) {
+    for ([[maybe_unused]] const auto &[unused, argument] : m_argument_map) {
       argument->validate();
     }
   }
@@ -1056,8 +1049,9 @@ public:
    * @throws std::logic_error if the option has no value
    * @throws std::bad_any_cast if the option is not of type T
    */
-  template <typename T = std::string> auto get(std::string_view arg_name) const
-    -> std::conditional_t<details::IsContainer<T>, T, const T&> {
+  template <typename T = std::string>
+  auto get(std::string_view arg_name) const
+      -> std::conditional_t<details::IsContainer<T>, T, const T &> {
     if (!m_is_parsed) {
       throw std::logic_error("Nothing parsed, no arguments are available.");
     }
@@ -1220,7 +1214,7 @@ private:
       return 0;
     }
     std::size_t max_size = 0;
-    for ([[maybe_unused]] const auto& [unused, argument] : m_argument_map) {
+    for ([[maybe_unused]] const auto &[unused, argument] : m_argument_map) {
       max_size = std::max(max_size, argument->get_arguments_length());
     }
     return max_size;

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -855,11 +855,11 @@ private:
       if constexpr (details::IsContainer<T>) {
         return any_cast_container<T>(m_values);
       } else {
-        return *std::any_cast<T>(&m_values.front());
+        return std::any_cast<const T &>(m_values.front());
       }
     }
     if (m_default_value.has_value()) {
-      return *std::any_cast<T>(&m_default_value);
+      return std::any_cast<const T &>(m_default_value);
     }
     if constexpr (details::IsContainer<T>) {
       if (!m_accepts_optional_like_value) {
@@ -893,9 +893,10 @@ private:
     using ValueType = typename T::value_type;
 
     T result;
-    std::transform(
-        std::begin(operand), std::end(operand), std::back_inserter(result),
-        [](const auto &value) { return *std::any_cast<ValueType>(&value); });
+    std::transform(std::begin(operand), std::end(operand),
+                   std::back_inserter(result), [](const auto &value) {
+                     return std::any_cast<const ValueType &>(value);
+                   });
     return result;
   }
 

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -849,43 +849,66 @@ private:
    * @throws std::logic_error in case of incompatible types
    */
   template <typename T>
-  auto get() const
-      -> std::conditional_t<details::IsContainer<T>, T, const T &> {
+  auto get() const -> std::enable_if_t<details::IsContainer<T>, T> {
     if (!m_values.empty()) {
-      if constexpr (details::IsContainer<T>) {
-        return any_cast_container<T>(m_values);
-      } else {
-        return std::any_cast<const T &>(m_values.front());
-      }
+      return any_cast_container<T>(m_values);
     }
     if (m_default_value.has_value()) {
       return std::any_cast<const T &>(m_default_value);
     }
-    if constexpr (details::IsContainer<T>) {
-      if (!m_accepts_optional_like_value) {
-        return any_cast_container<T>(m_values);
-      }
+    if (!m_accepts_optional_like_value) {
+      return any_cast_container<T>(m_values);
     }
 
     throw std::logic_error("No value provided for '" + m_names.back() + "'.");
   }
 
   /*
+   * Get argument value given a type
+   * @throws std::logic_error in case of incompatible types
+   */
+  template <typename T>
+  auto get() const -> std::enable_if_t<!details::IsContainer<T>, const T &> {
+    if (!m_values.empty()) {
+      return std::any_cast<const T &>(m_values.front());
+    }
+    if (m_default_value.has_value()) {
+      return std::any_cast<const T &>(m_default_value);
+    }
+
+    throw std::logic_error("No value provided for '" + m_names.back() + "'.");
+  }
+
+  /*
+   * Get argument value given a container type.
+   * @pre The object has no default value.
+   * @returns The stored values emplaced in T.
+   */
+  template <typename T>
+  auto present() const -> std::enable_if_t<details::IsContainer<T>, T> {
+    if (m_default_value.has_value()) {
+      throw std::logic_error(
+          "Arguments with default values are always present.");
+    }
+    return any_cast_container<T>(m_values);
+  }
+
+  /*
    * Get argument value given a type.
    * @pre The object has no default value.
-   * @returns The stored value if any, std::nullopt otherwise.
+   * @returns The pointer to stored value if any.
    */
-  template <typename T> auto present() const -> std::optional<T> {
+  template <typename T>
+  auto present() const
+      -> std::enable_if_t<!details::IsContainer<T>, const T *> {
     if (m_default_value.has_value()) {
-      throw std::logic_error("Argument with default value always presents");
+      throw std::logic_error(
+          "Arguments with default values are always present.");
     }
     if (m_values.empty()) {
-      return std::nullopt;
+      return nullptr;
     }
-    if constexpr (details::IsContainer<T>) {
-      return any_cast_container<T>(m_values);
-    }
-    return std::any_cast<T>(m_values.front());
+    return std::any_cast<T>(&m_values.front());
   }
 
   template <typename T>
@@ -1065,7 +1088,8 @@ public:
    * @throws std::bad_any_cast if the option is not of type T
    */
   template <typename T = std::string>
-  auto present(std::string_view arg_name) const -> std::optional<T> {
+  auto present(std::string_view arg_name) const
+      -> std::conditional_t<details::IsContainer<T>, T, const T *> {
     return (*this)[arg_name].present<T>();
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ file(GLOB ARGPARSE_TEST_SOURCES
     test_container_arguments.cpp
     test_const_correct.cpp
     test_default_args.cpp
+    test_approximate_arguments.cpp
     test_get.cpp
     test_help.cpp
     test_invalid_arguments.cpp

--- a/test/test_approximate_arguments.cpp
+++ b/test/test_approximate_arguments.cpp
@@ -1,0 +1,83 @@
+#include <argparse/argparse.hpp>
+#include <doctest.hpp>
+
+using doctest::test_suite;
+
+TEST_CASE("Parse approximate options with no proximity (default)" *
+          test_suite("approximate_arguments")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--config").nargs(1);
+  program.add_argument("--build").nargs(1);
+  REQUIRE_THROWS(
+      program.parse_args({"test", "--confi", "test", "--builo", "dev"}));
+}
+
+TEST_CASE("Parse approximate options with proximity of 1" *
+          test_suite("approximate_arguments")) {
+  argparse::ArgumentParser program("test");
+  program.set_proximity(1);
+  program.add_argument("--config").nargs(1);
+  program.add_argument("--build").nargs(1);
+
+  program.parse_args({"test", "--confi", "test", "--buil", "dev"});
+  REQUIRE(program.get<std::string>("--config") == "test");
+  REQUIRE(program.get<std::string>("--build") == "dev");
+  REQUIRE_THROWS(
+      program.parse_args({"test", "--conf", "test", "--bilud", "dev"}));
+}
+
+TEST_CASE("Parse approximate options with proximity of 2" *
+          test_suite("approximate_arguments")) {
+  // Deletion
+  {
+    argparse::ArgumentParser program("test");
+    program.set_proximity(2);
+    program.add_argument("--config").nargs(1);
+    program.add_argument("--build").nargs(1);
+    program.parse_args({"test", "--confi", "test", "--bui", "dev"});
+    REQUIRE(program.get<std::string>("--config") == "test");
+    REQUIRE(program.get<std::string>("--build") == "dev");
+  }
+
+  // Insertion
+  {
+    argparse::ArgumentParser program("test");
+    program.set_proximity(2);
+    program.add_argument("--config").nargs(1);
+    program.add_argument("--build").nargs(1);
+    program.parse_args({"test", "--configg", "test", "--builldd", "dev"});
+    REQUIRE(program.get<std::string>("--config") == "test");
+    REQUIRE(program.get<std::string>("--build") == "dev");
+  }
+
+  // Transposition
+  {
+    argparse::ArgumentParser program("test");
+    program.set_proximity(2);
+    program.add_argument("--config").nargs(1);
+    program.add_argument("--build").nargs(1);
+    program.parse_args({"test", "--confgi", "test", "--biudl", "dev"});
+    REQUIRE(program.get<std::string>("--config") == "test");
+    REQUIRE(program.get<std::string>("--build") == "dev");
+  }
+
+  // Substitution
+  {
+    argparse::ArgumentParser program("test");
+    program.set_proximity(2);
+    program.add_argument("--config").nargs(1);
+    program.add_argument("--build").nargs(1);
+    program.parse_args({"test", "--confug", "test", "--biold", "dev"});
+    REQUIRE(program.get<std::string>("--config") == "test");
+    REQUIRE(program.get<std::string>("--build") == "dev");
+  }
+}
+
+TEST_CASE("Parse approximate options with proximity of 5" *
+          test_suite("approximate_arguments")) {
+  argparse::ArgumentParser program("test");
+  program.set_proximity(5);
+  program.add_argument("--abcdefghijklmnop").nargs(1);
+  program.parse_args({"test", "--badcfehgjiklmnop", "test"});
+  REQUIRE(program.get<std::string>("--abcdefghijklmnop") == "test");
+}

--- a/test/test_parse_args.cpp
+++ b/test/test_parse_args.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Parse a string argument without default value" *
     THEN("the option is nullopt") {
       auto opt = program.present("--config");
       REQUIRE_FALSE(opt);
-      REQUIRE(opt == std::nullopt);
+      REQUIRE(opt == nullptr);
     }
   }
 
@@ -147,8 +147,7 @@ TEST_CASE("Parse a vector of float without default value" *
 
     THEN("the option is nullopt") {
       auto opt = program.present<std::vector<float>>("--vector");
-      REQUIRE_FALSE(opt.has_value());
-      REQUIRE(opt == std::nullopt);
+      REQUIRE(opt.size() == 0);
     }
   }
 
@@ -156,10 +155,7 @@ TEST_CASE("Parse a vector of float without default value" *
     program.parse_args({"test", "--vector", ".3", "1.3", "6"});
 
     THEN("the option has a value") {
-      auto opt = program.present<std::vector<float>>("--vector");
-      REQUIRE(opt.has_value());
-
-      auto &&vec = opt.value();
+      auto &&vec = program.present<std::vector<float>>("--vector");
       REQUIRE(vec.size() == 3);
       REQUIRE(vec[0] == .3f);
       REQUIRE(vec[1] == 1.3f);


### PR DESCRIPTION
This PR adds fuzzy matching to the argument parser. It uses a form of [Damerau-Levenshtein](https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance) optimized for memory and to return false as quick as possible.