### PR TITLE
Refactoring `present` and `get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ if (auto fn = program.present("-o")) {
 }
 ```
 
-Similar to `get`, the `present` method also accepts a template argument.  But rather than returning `T`, `parser.present<T>(key)` returns `std::optional<T>`, so that when the user does not provide a value to this parameter, the return value compares equal to `std::nullopt`.
+Similar to `get`, the `present` method also accepts a template argument.  If `T` is not a container, than rather than returning `T`, `parser.present<T>(key)` returns `T *`, so that when the user does not provide a value to this parameter, the return value equals to `nullptr`. If `T` is a container, than `T` returns an empty container if there are no arguments.
 
 #### Deciding if the value was given by the user
 

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -149,8 +149,9 @@ constexpr bool standard_integer =
     standard_signed_integer<T> || standard_unsigned_integer<T>;
 
 template <class F, class Tuple, class Extra, std::size_t... I>
-constexpr decltype(auto) apply_plus_one_impl(F &&f, Tuple &&t, Extra &&x,
-                                             std::index_sequence<I...> /*unused*/) {
+constexpr decltype(auto)
+apply_plus_one_impl(F &&f, Tuple &&t, Extra &&x,
+                    std::index_sequence<I...> /*unused*/) {
   return std::invoke(std::forward<F>(f), std::get<I>(std::forward<Tuple>(t))...,
                      std::forward<Extra>(x));
 }
@@ -328,11 +329,7 @@ template <class T> struct parse_number<T, chars_format::fixed> {
 
 } // namespace details
 
-enum class nargs_pattern {
-  optional,
-  any,
-  at_least_one
-};
+enum class nargs_pattern { optional, any, at_least_one };
 
 enum class default_arguments : unsigned int {
   none = 0,
@@ -429,7 +426,8 @@ public:
 
     if constexpr (is_one_of(Shape, 'd') && details::standard_integer<T>) {
       action(details::parse_number<T, details::radix_10>());
-    } else if constexpr (is_one_of(Shape, 'i') && details::standard_integer<T>) {
+    } else if constexpr (is_one_of(Shape, 'i') &&
+                         details::standard_integer<T>) {
       action(details::parse_number<T>());
     } else if constexpr (is_one_of(Shape, 'u') &&
                          details::standard_unsigned_integer<T>) {
@@ -506,7 +504,8 @@ public:
       std::visit([](const auto &f) { f({}); }, m_action);
       return start;
     }
-    if ((dist = static_cast<std::size_t>(std::distance(start, end))) >= num_args_min) {
+    if ((dist = static_cast<std::size_t>(std::distance(start, end))) >=
+        num_args_min) {
       if (num_args_max < dist) {
         end = std::next(start, num_args_max);
       }
@@ -558,7 +557,8 @@ public:
         throw_required_arg_no_value_provided_error();
       }
     } else {
-      if (!m_num_args_range.contains(m_values.size()) && !m_default_value.has_value()) {
+      if (!m_num_args_range.contains(m_values.size()) &&
+          !m_default_value.has_value()) {
         throw_nargs_range_validation_error();
       }
     }
@@ -606,15 +606,13 @@ public:
       return get<T>() == rhs;
     } else {
       auto lhs = get<T>();
-      return std::equal(std::begin(lhs), std::end(lhs), std::begin(rhs),
-                        std::end(rhs), [](const auto &lhs, const auto &rhs) {
-                          return lhs == rhs;
-                        });
+      return std::equal(
+          std::begin(lhs), std::end(lhs), std::begin(rhs), std::end(rhs),
+          [](const auto &lhs, const auto &rhs) { return lhs == rhs; });
     }
   }
 
 private:
-
   class NArgsRange {
     std::size_t m_min;
     std::size_t m_max;
@@ -631,21 +629,15 @@ private:
       return value >= m_min && value <= m_max;
     }
 
-    bool is_exact() const {
-      return m_min == m_max;
-    }
+    bool is_exact() const { return m_min == m_max; }
 
     bool is_right_bounded() const {
       return m_max < std::numeric_limits<std::size_t>::max();
     }
 
-    std::size_t get_min() const {
-      return m_min;
-    }
+    std::size_t get_min() const { return m_min; }
 
-    std::size_t get_max() const {
-      return m_max;
-    }
+    std::size_t get_max() const { return m_max; }
   };
 
   void throw_nargs_range_validation_error() const {
@@ -656,7 +648,8 @@ private:
     if (m_num_args_range.is_exact()) {
       stream << m_num_args_range.get_min();
     } else if (m_num_args_range.is_right_bounded()) {
-      stream << m_num_args_range.get_min() << " to " << m_num_args_range.get_max();
+      stream << m_num_args_range.get_min() << " to "
+             << m_num_args_range.get_max();
     } else {
       stream << m_num_args_range.get_min() << " or more";
     }
@@ -855,7 +848,9 @@ private:
    * Get argument value given a type
    * @throws std::logic_error in case of incompatible types
    */
-  template <typename T> auto get() const -> std::conditional_t<details::IsContainer<T>, T, const T&> {
+  template <typename T>
+  auto get() const
+      -> std::conditional_t<details::IsContainer<T>, T, const T &> {
     if (!m_values.empty()) {
       if constexpr (details::IsContainer<T>) {
         return any_cast_container<T>(m_values);
@@ -916,7 +911,7 @@ private:
       std::in_place_type<valued_action>,
       [](const std::string &value) { return value; }};
   std::vector<std::any> m_values;
-  NArgsRange m_num_args_range {1, 1};
+  NArgsRange m_num_args_range{1, 1};
   bool m_accepts_optional_like_value = false;
   bool m_is_optional : true;
   bool m_is_required : true;
@@ -932,7 +927,7 @@ public:
       : m_program_name(std::move(program_name)), m_version(std::move(version)) {
     if ((add_args & default_arguments::help) == default_arguments::help) {
       add_argument("-h", "--help")
-          .action([&](const auto &/*unused*/) {
+          .action([&](const auto & /*unused*/) {
             std::cout << help().str();
             std::exit(0);
           })
@@ -943,7 +938,7 @@ public:
     }
     if ((add_args & default_arguments::version) == default_arguments::version) {
       add_argument("-v", "--version")
-          .action([&](const auto &/*unused*/) {
+          .action([&](const auto & /*unused*/) {
             std::cout << m_version << std::endl;
             std::exit(0);
           })
@@ -958,10 +953,8 @@ public:
   ArgumentParser &operator=(ArgumentParser &&) = default;
 
   ArgumentParser(const ArgumentParser &other)
-      : m_program_name(other.m_program_name),
-        m_version(other.m_version),
-        m_description(other.m_description),
-        m_epilog(other.m_epilog),
+      : m_program_name(other.m_program_name), m_version(other.m_version),
+        m_description(other.m_description), m_epilog(other.m_epilog),
         m_is_parsed(other.m_is_parsed),
         m_positional_arguments(other.m_positional_arguments),
         m_optional_arguments(other.m_optional_arguments) {
@@ -1036,7 +1029,7 @@ public:
   void parse_args(const std::vector<std::string> &arguments) {
     parse_args_internal(arguments);
     // Check if all arguments are parsed
-    for ([[maybe_unused]] const auto& [unused, argument] : m_argument_map) {
+    for ([[maybe_unused]] const auto &[unused, argument] : m_argument_map) {
       argument->validate();
     }
   }
@@ -1056,8 +1049,9 @@ public:
    * @throws std::logic_error if the option has no value
    * @throws std::bad_any_cast if the option is not of type T
    */
-  template <typename T = std::string> auto get(std::string_view arg_name) const
-    -> std::conditional_t<details::IsContainer<T>, T, const T&> {
+  template <typename T = std::string>
+  auto get(std::string_view arg_name) const
+      -> std::conditional_t<details::IsContainer<T>, T, const T &> {
     if (!m_is_parsed) {
       throw std::logic_error("Nothing parsed, no arguments are available.");
     }
@@ -1220,7 +1214,7 @@ private:
       return 0;
     }
     std::size_t max_size = 0;
-    for ([[maybe_unused]] const auto& [unused, argument] : m_argument_map) {
+    for ([[maybe_unused]] const auto &[unused, argument] : m_argument_map) {
       max_size = std::max(max_size, argument->get_arguments_length());
     }
     return max_size;

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -855,11 +855,11 @@ private:
       if constexpr (details::IsContainer<T>) {
         return any_cast_container<T>(m_values);
       } else {
-        return *std::any_cast<T>(&m_values.front());
+        return std::any_cast<const T &>(m_values.front());
       }
     }
     if (m_default_value.has_value()) {
-      return *std::any_cast<T>(&m_default_value);
+      return std::any_cast<const T &>(m_default_value);
     }
     if constexpr (details::IsContainer<T>) {
       if (!m_accepts_optional_like_value) {
@@ -893,9 +893,10 @@ private:
     using ValueType = typename T::value_type;
 
     T result;
-    std::transform(
-        std::begin(operand), std::end(operand), std::back_inserter(result),
-        [](const auto &value) { return *std::any_cast<ValueType>(&value); });
+    std::transform(std::begin(operand), std::end(operand),
+                   std::back_inserter(result), [](const auto &value) {
+                     return std::any_cast<const ValueType &>(value);
+                   });
     return result;
   }
 

--- a/test/test_help.cpp
+++ b/test/test_help.cpp
@@ -1,6 +1,7 @@
 #include <argparse/argparse.hpp>
 #include <doctest.hpp>
 #include <sstream>
+#include <optional>
 
 using doctest::test_suite;
 

--- a/test/test_parse_args.cpp
+++ b/test/test_parse_args.cpp
@@ -35,10 +35,10 @@ TEST_CASE("Parse a string argument without default value" *
   WHEN("no value provided") {
     program.parse_args({"test"});
 
-    THEN("the option is nullopt") {
+    THEN("the option is nullptr") {
       auto opt = program.present("--config");
       REQUIRE_FALSE(opt);
-      REQUIRE(opt == std::nullopt);
+      REQUIRE(opt == nullptr);
     }
   }
 
@@ -145,10 +145,9 @@ TEST_CASE("Parse a vector of float without default value" *
   WHEN("no value is provided") {
     program.parse_args({"test"});
 
-    THEN("the option is nullopt") {
+    THEN("the option is an empty container") {
       auto opt = program.present<std::vector<float>>("--vector");
-      REQUIRE_FALSE(opt.has_value());
-      REQUIRE(opt == std::nullopt);
+      REQUIRE(opt.empty());
     }
   }
 
@@ -156,10 +155,7 @@ TEST_CASE("Parse a vector of float without default value" *
     program.parse_args({"test", "--vector", ".3", "1.3", "6"});
 
     THEN("the option has a value") {
-      auto opt = program.present<std::vector<float>>("--vector");
-      REQUIRE(opt.has_value());
-
-      auto &&vec = opt.value();
+      auto &&vec = program.present<std::vector<float>>("--vector");
       REQUIRE(vec.size() == 3);
       REQUIRE(vec[0] == .3f);
       REQUIRE(vec[1] == 1.3f);


### PR DESCRIPTION
This PR does a few things:

* Formats the code.
* Replaces pointer `any_cast`s with reference `any_cast`s.
* Removes the use of optional from `present`
* Separates `get` into container and non-container counterparts.
* Separates `present` into container and non-container counterparts.
* For containers, `present` always returns at least an empty container.