### PR TITLE
parse_known_args

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
      *    [Gathering Remaining Arguments](#gathering-remaining-arguments)
      *    [Parent Parsers](#parent-parsers)
      *    [Subcommands](#subcommands)
+     *    [Parse Known Args](#parse-known-args)
 *    [Further Examples](#further-examples)
      *    [Construct a JSON object from a filename argument](#construct-a-json-object-from-a-filename-argument)
      *    [Positional Arguments with Compound Toggle Arguments](#positional-arguments-with-compound-toggle-arguments)
@@ -798,6 +799,28 @@ update       	Update the registered submodules to match what the superproject ex
 When a help message is requested from a subparser, only the help for that particular parser will be printed. The help message will not include parent parser or sibling parser messages.
 
 Additionally, every parser has a `.is_subcommand_used("<command_name>")` member function to check if a subcommand was used. 
+
+### Parse Known Args
+
+Sometimes a program may only parse a few of the command-line arguments, passing the remaining arguments on to another script or program. In these cases, the `parse_known_args()` function can be useful. It works much like `parse_args()` except that it does not produce an error when extra arguments are present. Instead, it returns a list of remaining argument strings.
+
+```cpp
+#include <argparse/argparse.hpp>
+#include <cassert>
+
+int main(int argc, char *argv[]) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--foo").implicit_value(true).default_value(false);
+  program.add_argument("bar");
+
+  auto unknown_args =
+    program.parse_known_args({"test", "--foo", "--badger", "BAR", "spam"});
+
+  assert(program.get<bool>("--foo") == true);
+  assert(program.get<std::string>("bar") == std::string{"BAR"});
+  assert((unknown_args == std::vector<std::string>{"--badger", "spam"}));
+}
+```
 
 ## Further Examples
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,7 @@ file(GLOB ARGPARSE_TEST_SOURCES
     test_value_semantics.cpp
     test_version.cpp
     test_subparsers.cpp
+    test_parse_known_args.cpp
 )
 set_source_files_properties(main.cpp
     PROPERTIES

--- a/test/test_parse_known_args.cpp
+++ b/test/test_parse_known_args.cpp
@@ -1,0 +1,82 @@
+#include <argparse/argparse.hpp>
+#include <doctest.hpp>
+
+using doctest::test_suite;
+
+TEST_CASE("Parse unknown optional and positional arguments without exceptions" *
+          test_suite("parse_known_args")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--foo").implicit_value(true).default_value(false);
+  program.add_argument("bar");
+
+  SUBCASE("Parse unknown optional and positional arguments") {
+    auto unknown_args =
+        program.parse_known_args({"test", "--foo", "--badger", "BAR", "spam"});
+    REQUIRE((unknown_args == std::vector<std::string>{"--badger", "spam"}));
+    REQUIRE(program.get<bool>("--foo") == true);
+    REQUIRE(program.get<std::string>("bar") == std::string{"BAR"});
+  }
+
+  SUBCASE("Parse unknown compound arguments") {
+    auto unknown_args = program.parse_known_args({"test", "-jc", "BAR"});
+    REQUIRE((unknown_args == std::vector<std::string>{"-jc"}));
+    REQUIRE(program.get<bool>("--foo") == false);
+    REQUIRE(program.get<std::string>("bar") == std::string{"BAR"});
+  }
+}
+
+TEST_CASE("Parse unknown optional and positional arguments in subparsers "
+          "without exceptions" *
+          test_suite("parse_known_args")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--output");
+
+  argparse::ArgumentParser command_1("add");
+  command_1.add_argument("file").nargs(2);
+
+  argparse::ArgumentParser command_2("clean");
+  command_2.add_argument("--fullclean")
+      .default_value(false)
+      .implicit_value(true);
+
+  program.add_subparser(command_1);
+  program.add_subparser(command_2);
+
+  SUBCASE("Parse unknown optional argument") {
+    auto unknown_args =
+        program.parse_known_args({"test", "add", "--badger", "BAR", "spam"});
+    REQUIRE(program.is_subcommand_used("add") == true);
+    REQUIRE((command_1.get<std::vector<std::string>>("file") ==
+             std::vector<std::string>{"BAR", "spam"}));
+    REQUIRE((unknown_args == std::vector<std::string>{"--badger"}));
+  }
+
+  SUBCASE("Parse unknown positional argument") {
+    auto unknown_args =
+        program.parse_known_args({"test", "add", "FOO", "BAR", "spam"});
+    REQUIRE(program.is_subcommand_used("add") == true);
+    REQUIRE((command_1.get<std::vector<std::string>>("file") ==
+             std::vector<std::string>{"FOO", "BAR"}));
+    REQUIRE((unknown_args == std::vector<std::string>{"spam"}));
+  }
+
+  SUBCASE("Parse unknown positional and optional arguments") {
+    auto unknown_args = program.parse_known_args(
+        {"test", "add", "--verbose", "FOO", "5", "BAR", "-jn", "spam"});
+    REQUIRE(program.is_subcommand_used("add") == true);
+    REQUIRE((command_1.get<std::vector<std::string>>("file") ==
+             std::vector<std::string>{"FOO", "5"}));
+    REQUIRE((unknown_args ==
+             std::vector<std::string>{"--verbose", "BAR", "-jn", "spam"}));
+  }
+
+  SUBCASE("Parse unknown positional and optional arguments 2") {
+    auto unknown_args =
+        program.parse_known_args({"test", "clean", "--verbose", "FOO", "5",
+                                  "BAR", "--fullclean", "-jn", "spam"});
+    REQUIRE(program.is_subcommand_used("clean") == true);
+    REQUIRE(command_2.get<bool>("--fullclean") == true);
+    REQUIRE((unknown_args == std::vector<std::string>{"--verbose", "FOO", "5",
+                                                      "BAR", "-jn", "spam"}));
+  }
+}


### PR DESCRIPTION
Closes #181 

This PR adds a `parse_known_args` support.

Sometimes a program may only parse a few of the command-line arguments, passing the remaining arguments on to another script or program. In these cases, the `parse_known_args()` function can be useful. It works much like `parse_args()` except that it does not produce an error when extra arguments are present. Instead, it returns a list of remaining argument strings.

```cpp
#include <argparse/argparse.hpp>
#include <cassert>

int main(int argc, char *argv[]) {
  argparse::ArgumentParser program("test");
  program.add_argument("--foo").implicit_value(true).default_value(false);
  program.add_argument("bar");

  auto unknown_args =
    program.parse_known_args({"test", "--foo", "--badger", "BAR", "spam"});

  assert(program.get<bool>("--foo") == true);
  assert(program.get<std::string>("bar") == std::string{"BAR"});
  assert((unknown_args == std::vector<std::string>{"--badger", "spam"}));
}
```