### PR TITLE
Closes #67: option-value syntax support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
      *    [Subcommands](#subcommands)
      *    [Parse Known Args](#parse-known-args)
      *    [Custom Prefix Characters](#custom-prefix-characters)
+     *    [Custom Assignment Characters](#custom-assignment-characters)
 *    [Further Examples](#further-examples)
      *    [Construct a JSON object from a filename argument](#construct-a-json-object-from-a-filename-argument)
      *    [Positional Arguments with Compound Toggle Arguments](#positional-arguments-with-compound-toggle-arguments)
@@ -826,7 +827,9 @@ int main(int argc, char *argv[]) {
 
 ### Custom Prefix Characters 
 
-Most command-line options will use `-` as the prefix, e.g. `-f/--foo`. Parsers that need to support different or additional prefix characters, e.g. for options like `+f` or `/foo`, may specify them using the `set_prefix_chars()`:
+Most command-line options will use `-` as the prefix, e.g. `-f/--foo`. Parsers that need to support different or additional prefix characters, e.g. for options like `+f` or `/foo`, may specify them using the `set_prefix_chars()`.
+
+The default prefix character is `-`.
 
 ```cpp
 #include <argparse/argparse.hpp>
@@ -868,6 +871,49 @@ foo@bar:/home/dev/$ ./main +f 5 --bar 3.14f /foo "Hello"
 +f    : 5
 --bar : 3.14f
 /foo  : Hello
+```
+
+### Custom Assignment Characters 
+
+In addition to prefix characters, custom 'assign' characters can be set. This setting is used to allow invocations like `./test --foo=Foo /B:Bar`.
+
+The default assign character is `=`.
+
+```cpp
+#include <argparse/argparse.hpp>
+#include <cassert>
+
+int main(int argc, char *argv[]) {
+  argparse::ArgumentParser program("test");
+  program.set_prefix_chars("-+/");
+  program.set_assign_chars("=:");
+
+  program.add_argument("--foo");
+  program.add_argument("/B");
+
+  try {
+    program.parse_args(argc, argv);
+  }
+  catch (const std::runtime_error& err) {
+    std::cerr << err.what() << std::endl;
+    std::cerr << program;
+    std::exit(1);
+  }
+
+  if (program.is_used("--foo")) {
+    std::cout << "--foo : " << program.get("--foo") << "\n";
+  }
+
+  if (program.is_used("/B")) {
+    std::cout << "/B    : " << program.get("/B") << "\n";
+  }
+}
+```
+
+```console
+foo@bar:/home/dev/$ ./main --foo=Foo /B:Bar
+--foo : Foo
+/B    : Bar
 ```
 
 ## Further Examples

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
      *    [Parent Parsers](#parent-parsers)
      *    [Subcommands](#subcommands)
      *    [Parse Known Args](#parse-known-args)
+     *    [Custom Prefix Characters](#custom-prefix-characters)
 *    [Further Examples](#further-examples)
      *    [Construct a JSON object from a filename argument](#construct-a-json-object-from-a-filename-argument)
      *    [Positional Arguments with Compound Toggle Arguments](#positional-arguments-with-compound-toggle-arguments)
@@ -821,6 +822,52 @@ int main(int argc, char *argv[]) {
   assert(program.get<std::string>("bar") == std::string{"BAR"});
   assert((unknown_args == std::vector<std::string>{"--badger", "spam"}));
 }
+```
+
+### Custom Prefix Characters 
+
+Most command-line options will use `-` as the prefix, e.g. `-f/--foo`. Parsers that need to support different or additional prefix characters, e.g. for options like `+f` or `/foo`, may specify them using the `set_prefix_chars()`:
+
+```cpp
+#include <argparse/argparse.hpp>
+#include <cassert>
+
+int main(int argc, char *argv[]) {
+  argparse::ArgumentParser program("test");
+  program.set_prefix_chars("-+/");
+
+  program.add_argument("+f");
+  program.add_argument("--bar");
+  program.add_argument("/foo");
+
+  try {
+    program.parse_args(argc, argv);
+  }
+  catch (const std::runtime_error& err) {
+    std::cerr << err.what() << std::endl;
+    std::cerr << program;
+    std::exit(1);
+  }
+
+  if (program.is_used("+f")) {
+    std::cout << "+f    : " << program.get("+f") << "\n";
+  }
+
+  if (program.is_used("--bar")) {
+    std::cout << "--bar : " << program.get("--bar") << "\n";
+  }
+
+  if (program.is_used("/foo")) {
+    std::cout << "/foo  : " << program.get("/foo") << "\n";
+  }  
+}
+```
+
+```console
+foo@bar:/home/dev/$ ./main +f 5 --bar 3.14f /foo "Hello"
++f    : 5
+--bar : 3.14f
+/foo  : Hello
 ```
 
 ## Further Examples

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,7 @@ file(GLOB ARGPARSE_TEST_SOURCES
     test_subparsers.cpp
     test_parse_known_args.cpp
     test_equals_form.cpp
+    test_prefix_chars.cpp
 )
 set_source_files_properties(main.cpp
     PROPERTIES

--- a/test/test_prefix_chars.cpp
+++ b/test/test_prefix_chars.cpp
@@ -1,0 +1,41 @@
+#include <argparse/argparse.hpp>
+#include <cmath>
+#include <doctest.hpp>
+
+using doctest::test_suite;
+
+TEST_CASE("Parse with custom prefix chars" * test_suite("prefix_chars")) {
+  argparse::ArgumentParser program("test");
+  program.set_prefix_chars("-+");
+  program.add_argument("+f");
+  program.add_argument("++bar");
+  program.parse_args({"test", "+f", "X", "++bar", "Y"});
+  REQUIRE(program.get("+f") == "X");
+  REQUIRE(program.get("++bar") == "Y");
+}
+
+TEST_CASE("Parse with custom Windows-style prefix chars" *
+          test_suite("prefix_chars")) {
+  argparse::ArgumentParser program("dir");
+  program.set_prefix_chars("/");
+  program.add_argument("/A").nargs(1);
+  program.add_argument("/B").default_value(false).implicit_value(true);
+  program.add_argument("/C").default_value(false).implicit_value(true);
+  program.parse_args({"dir", "/A", "D", "/B", "/C"});
+  REQUIRE(program.get("/A") == "D");
+  REQUIRE(program.get<bool>("/B") == true);
+}
+
+TEST_CASE("Parse with custom Windows-style prefix chars and assign chars" *
+          test_suite("prefix_chars")) {
+  argparse::ArgumentParser program("dir");
+  program.set_prefix_chars("/");
+  program.set_assign_chars(":=");
+  program.add_argument("/A").nargs(1);
+  program.add_argument("/B").nargs(1);
+  program.add_argument("/C").default_value(false).implicit_value(true);
+  program.parse_args({"dir", "/A:D", "/B=Boo", "/C"});
+  REQUIRE(program.get("/A") == "D");
+  REQUIRE(program.get("/B") == "Boo");
+  REQUIRE(program.get<bool>("/C") == true);
+}


### PR DESCRIPTION
This PR adds support for custom `prefix_chars` and `assign_chars`

### Custom Prefix Characters 

Most command-line options will use `-` as the prefix, e.g. `-f/--foo`. Parsers that need to support different or additional prefix characters, e.g. for options like `+f` or `/foo`, may specify them using the `set_prefix_chars()`.

The default prefix character is `-`.

```cpp
#include <argparse/argparse.hpp>
#include <cassert>

int main(int argc, char *argv[]) {
  argparse::ArgumentParser program("test");
  program.set_prefix_chars("-+/");

  program.add_argument("+f");
  program.add_argument("--bar");
  program.add_argument("/foo");

  try {
    program.parse_args(argc, argv);
  }
  catch (const std::runtime_error& err) {
    std::cerr << err.what() << std::endl;
    std::cerr << program;
    std::exit(1);
  }

  if (program.is_used("+f")) {
    std::cout << "+f    : " << program.get("+f") << "\n";
  }

  if (program.is_used("--bar")) {
    std::cout << "--bar : " << program.get("--bar") << "\n";
  }

  if (program.is_used("/foo")) {
    std::cout << "/foo  : " << program.get("/foo") << "\n";
  }  
}
```

```console
foo@bar:/home/dev/$ ./main +f 5 --bar 3.14f /foo "Hello"
+f    : 5
--bar : 3.14f
/foo  : Hello
```

### Custom Assignment Characters 

In addition to prefix characters, custom 'assign' characters can be set. This setting is used to allow invocations like `./test --foo=Foo /B:Bar`.

The default assign character is `=`.

```cpp
#include <argparse/argparse.hpp>
#include <cassert>

int main(int argc, char *argv[]) {
  argparse::ArgumentParser program("test");
  program.set_prefix_chars("-+/");
  program.set_assign_chars("=:");

  program.add_argument("--foo");
  program.add_argument("/B");

  try {
    program.parse_args(argc, argv);
  }
  catch (const std::runtime_error& err) {
    std::cerr << err.what() << std::endl;
    std::cerr << program;
    std::exit(1);
  }

  if (program.is_used("--foo")) {
    std::cout << "--foo : " << program.get("--foo") << "\n";
  }

  if (program.is_used("/B")) {
    std::cout << "/B    : " << program.get("/B") << "\n";
  }
}
```

```console
foo@bar:/home/dev/$ ./main --foo=Foo /B:Bar
--foo : Foo
/B    : Bar
```