### PR TITLE
Add an explicit MIT license to each sample source file

### DIFF
--- a/samples/compound_arguments.cpp
+++ b/samples/compound_arguments.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 
 int main(int argc, char *argv[]) {

--- a/samples/custom_assignment_characters.cpp
+++ b/samples/custom_assignment_characters.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 #include <cassert>
 

--- a/samples/custom_prefix_characters.cpp
+++ b/samples/custom_prefix_characters.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 #include <cassert>
 

--- a/samples/description_epilog_metavar.cpp
+++ b/samples/description_epilog_metavar.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 
 int main(int argc, char *argv[]) {

--- a/samples/gathering_remaining_arguments.cpp
+++ b/samples/gathering_remaining_arguments.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 
 int main(int argc, char *argv[]) {

--- a/samples/is_used.cpp
+++ b/samples/is_used.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 
 int main(int argc, char *argv[]) {

--- a/samples/joining_repeated_optional_arguments.cpp
+++ b/samples/joining_repeated_optional_arguments.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 
 int main(int argc, char *argv[]) {

--- a/samples/list_of_arguments.cpp
+++ b/samples/list_of_arguments.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 
 int main(int argc, char *argv[]) {

--- a/samples/negative_numbers.cpp
+++ b/samples/negative_numbers.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 
 int main(int argc, char *argv[]) {

--- a/samples/optional_flag_argument.cpp
+++ b/samples/optional_flag_argument.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 
 int main(int argc, char *argv[]) {

--- a/samples/parse_known_args.cpp
+++ b/samples/parse_known_args.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 #include <cassert>
 

--- a/samples/positional_argument.cpp
+++ b/samples/positional_argument.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 
 int main(int argc, char *argv[]) {

--- a/samples/repeating_argument_to_increase_value.cpp
+++ b/samples/repeating_argument_to_increase_value.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 
 int main(int argc, char *argv[]) {

--- a/samples/required_optional_argument.cpp
+++ b/samples/required_optional_argument.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 
 int main(int argc, char *argv[]) {

--- a/samples/subcommands.cpp
+++ b/samples/subcommands.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <argparse/argparse.hpp>
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
I'm a big fan of the samples directory. Personally, I learn APIs better from examples than specification docs.

I expect many people will copy and paste from the samples to start their own code. This is a good thing.

Therefor, I'd like to see explicit, per-file licenses on these samples.
