### PR TITLE
Fix std::string_view being identified as a container

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -63,6 +63,8 @@ struct HasContainerTraits : std::false_type {};
 
 template <> struct HasContainerTraits<std::string> : std::false_type {};
 
+template <> struct HasContainerTraits<std::string_view> : std::false_type {};
+
 template <typename T>
 struct HasContainerTraits<
     T, std::void_t<typename T::value_type, decltype(std::declval<T>().begin()),


### PR DESCRIPTION
This fixes `get<T>()` (and by extension `operator==`) for situations where a value is stored as a `std::string_view`.