### PR TITLE
Add is_subcommand_used overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,7 +825,7 @@ Subcommands:
 
 When a help message is requested from a subparser, only the help for that particular parser will be printed. The help message will not include parent parser or sibling parser messages.
 
-Additionally, every parser has a `.is_subcommand_used("<command_name>")` member function to check if a subcommand was used. 
+Additionally, every parser has the `.is_subcommand_used("<command_name>")` and `.is_subcommand_used(subparser)` member functions to check if a subcommand was used. 
 
 ### Parse Known Args
 

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -1255,11 +1255,16 @@ public:
     return (*this)[arg_name].m_is_used;
   }
 
-  /* Getter that returns true for user-supplied options. Returns false if not
-   * user-supplied, even with a default value.
+  /* Getter that returns true if a subcommand is used.
    */
   auto is_subcommand_used(std::string_view subcommand_name) const {
     return m_subparser_used.at(subcommand_name);
+  }
+
+  /* Getter that returns true if a subcommand is used.
+   */
+  auto is_subcommand_used(const ArgumentParser &subparser) const {
+    return is_subcommand_used(subparser.m_program_name);
   }
 
   /* Indexing operator. Return a reference to an Argument object


### PR DESCRIPTION
It's useful for removing string literals duplication in a code.