### PR TITLE
Added a fix for issue #235

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -1365,13 +1365,7 @@ public:
 
     // Add any options inline here
     for (const auto &argument : this->m_optional_arguments) {
-      if (argument.m_names.front() == "-v") {
-        continue;
-      } else if (argument.m_names.front() == "-h") {
-        stream << " [-h]";
-      } else {
-        stream << " " << argument.get_inline_usage();
-      }
+      stream << " " << argument.get_inline_usage();
     }
     // Put positional arguments after the optionals
     for (const auto &argument : this->m_positional_arguments) {


### PR DESCRIPTION
Added a fix for issue #235.

For the following code:
```
#include <argparse/argparse.hpp>

int main(int argc, char *argv[]) {
  argparse::ArgumentParser program("foo", "1.0", argparse::default_arguments::none);
  program.add_argument("-h", "--hint");
  program.add_argument("-v", "--verbose");
  program.add_argument("--bar");
  std::cout << program.usage();  // Usage: foo [--hint VAR] [--verbose VAR] [--bar VAR]
  
  return 0;
}
```
the output now is:- `Usage: foo [--hint VAR] [--verbose VAR] [--bar VAR]`

Thanks