### PR TITLE
Fix tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,4 +18,4 @@ CheckOptions:
   - { key: readability-identifier-naming.StructIgnoredRegexp, value: "parse_number" }
   - { key: readability-identifier-naming.VariableCase, value: lower_case }
 
-HeaderFilterRegex: '.*'
+HeaderFilterRegex: 'argparse/.+\.hpp'

--- a/.github/workflows/tidy-analysis-stage-01.yml
+++ b/.github/workflows/tidy-analysis-stage-01.yml
@@ -28,7 +28,7 @@ jobs:
       run: mkdir clang-tidy-result
 
     - name: Analyze
-      run: git diff -U0 HEAD^ | clang-tidy-diff-12.py -p1 -path build -extra-arg=-Iinclude -extra-arg=-std=c++17 -export-fixes clang-tidy-result/fixes.yml
+      run: git diff -U0 HEAD^ | clang-tidy-diff-12.py -p1 -regex ".+hpp" -extra-arg=-Iinclude -extra-arg=-std=c++17 -export-fixes clang-tidy-result/fixes.yml
 
     - name: Save PR metadata
       run: |


### PR DESCRIPTION
These changes limit clang-tidy checks to the main header.