### PR TITLE
Proposed update to remove RAII problem

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -1041,6 +1041,13 @@ private:
   std::string_view m_prefix_chars; // ArgumentParser has the prefix_chars
 };
 
+class NormalProgramTermination : public std::exception {
+public:
+  const char * what () {
+    return "Normal program termination is expected";
+  }
+};
+  
 class ArgumentParser {
 public:
   explicit ArgumentParser(std::string program_name = {},
@@ -1052,7 +1059,7 @@ public:
       add_argument("-h", "--help")
           .action([&](const auto & /*unused*/) {
             std::cout << help().str();
-            std::exit(0);
+            throw NormalProgramTermination();
           })
           .default_value(false)
           .help("shows help message and exits")
@@ -1063,7 +1070,7 @@ public:
       add_argument("-v", "--version")
           .action([&](const auto & /*unused*/) {
             std::cout << m_version << std::endl;
-            std::exit(0);
+            throw NormalProgramTermination();
           })
           .default_value(false)
           .help("prints version information and exits")


### PR DESCRIPTION
I propose the removal of the use of `std::exit`. It's usage breaks RAII which is not mentioned in the documentation.

As for the addition of the exception, during parsing we already require that the user catches several exceptions thus the whole `try/catch` harness is already there for a proper program. Adding a catch clause for the new `NormalProgramTermination` is a bit bulky but doesn't break RAII and is explicit on that the program should terminate in normal usage.