### PR TITLE
Install cmake export file in CMAKE_INSTALL_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,6 @@ option(ARGPARSE_LONG_VERSION_ARG_ONLY OFF)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
-string(REPLACE "/${CMAKE_LIBRARY_ARCHITECTURE}" "" CMAKE_INSTALL_LIBDIR_ARCHIND "${CMAKE_INSTALL_LIBDIR}")
-
 
 add_library(argparse INTERFACE)
 add_library(argparse::argparse ALIAS argparse)
@@ -41,7 +39,7 @@ if(ARGPARSE_INSTALL)
   install(TARGETS argparse EXPORT argparseConfig)
   install(EXPORT argparseConfig
           NAMESPACE argparse::
-          DESTINATION ${CMAKE_INSTALL_LIBDIR_ARCHIND}/cmake/${PROJECT_NAME})
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
   install(FILES ${CMAKE_CURRENT_LIST_DIR}/include/argparse/argparse.hpp
           DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/argparse)
 
@@ -64,7 +62,7 @@ if(ARGPARSE_INSTALL)
          NAMESPACE argparse::)
 
   install(FILES "${CMAKE_CONFIG_VERSION_FILE_NAME}"
-         DESTINATION "${CMAKE_INSTALL_LIBDIR_ARCHIND}/cmake/${PROJECT_NAME}")
+         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
   set(PackagingTemplatesDir "${CMAKE_CURRENT_SOURCE_DIR}/packaging")
 
@@ -94,7 +92,7 @@ if(ARGPARSE_INSTALL)
   set(PKG_CONFIG_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc")
   configure_file("${PackagingTemplatesDir}/pkgconfig.pc.in" "${PKG_CONFIG_FILE_NAME}" @ONLY)
   install(FILES "${PKG_CONFIG_FILE_NAME}"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR_ARCHIND}/pkgconfig"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
   )
 endif()
 


### PR DESCRIPTION
Per https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html#exporting-targets this is the standard way to do so, no need to hack CMAKE_INSTALL_LIBDIR_ARCHIND