### PR TITLE
implements column-aligned multi-line help message for arguments

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -649,6 +649,7 @@ public:
 
   friend std::ostream &operator<<(std::ostream &stream,
                                   const Argument &argument) {
+    auto stream_width = stream.width();
     std::stringstream name_stream;
     name_stream << "  "; // indent
     if (argument.is_positional(argument.m_names.front(),
@@ -668,7 +669,31 @@ public:
         name_stream << " " << argument.m_metavar;
       }
     }
-    stream << name_stream.str() << "\t" << argument.m_help;
+    auto spacing = name_stream.str().size();
+    auto pos = 0;
+    auto prev = 0;
+    auto first_line = true;
+    stream << name_stream.str();
+    while ((pos = argument.m_help.find('\n', prev)) != std::string::npos) {
+      auto line = argument.m_help.substr(prev, pos - prev + 1);
+      if (first_line) {
+        stream << "\t" << line;
+        first_line = false;
+      } else {
+        stream.width(stream_width);
+        stream << std::string(spacing, ' ') << "\t" << line;
+      }
+      prev += pos - prev + 1;
+    }
+    if (first_line)
+      stream << "\t" << argument.m_help;
+    else {
+      auto leftover = argument.m_help.substr(prev, argument.m_help.size() - prev);
+      if (leftover.size() > 0) {
+        stream.width(stream_width);
+        stream << std::string(spacing, ' ') << "\t" << leftover;
+      }
+    }
 
     // print nargs spec
     if (!argument.m_help.empty()) {


### PR DESCRIPTION
Hi, I'd like to provide this little implementation regarding column-aligned multi-line help message that works for arguments (not subcommands). This was discussed in https://github.com/p-ranav/argparse/issues/248 but the original poster didn't open a pull request.

In test_help.cpp I didn't see a test that validates the help message on a per-character level, so I didn't write any test.