### PR TITLE
Fix issue #248: Align multiline help messages

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -675,7 +675,7 @@ public:
     auto pos = 0;
     auto prev = 0;
     auto first_line = true;
-    const char* hspace = "  "; // minimal space between name and help message
+    auto hspace = "  "; // minimal space between name and help message
     stream << name_stream.str();
     std::string_view help_view(argument.m_help);
     while ((pos = argument.m_help.find('\n', prev)) != std::string::npos) {

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -649,6 +649,7 @@ public:
 
   friend std::ostream &operator<<(std::ostream &stream,
                                   const Argument &argument) {
+    auto stream_width = stream.width();
     std::stringstream name_stream;
     name_stream << "  "; // indent
     if (argument.is_positional(argument.m_names.front(),
@@ -668,7 +669,31 @@ public:
         name_stream << " " << argument.m_metavar;
       }
     }
-    stream << name_stream.str() << "\t" << argument.m_help;
+    auto spacing = name_stream.str().size();
+    auto pos = 0;
+    auto prev = 0;
+    auto first_line = true;
+    stream << name_stream.str();
+    while ((pos = argument.m_help.find('\n', prev)) != std::string::npos) {
+      auto line = argument.m_help.substr(prev, pos - prev + 1);
+      if (first_line) {
+        stream << "\t" << line;
+        first_line = false;
+      } else {
+        stream.width(stream_width);
+        stream << std::string(spacing, ' ') << "\t" << line;
+      }
+      prev += pos - prev + 1;
+    }
+    if (first_line)
+      stream << "\t" << argument.m_help;
+    else {
+      auto leftover = argument.m_help.substr(prev, argument.m_help.size() - prev);
+      if (leftover.size() > 0) {
+        stream.width(stream_width);
+        stream << std::string(spacing, ' ') << "\t" << leftover;
+      }
+    }
 
     // print nargs spec
     if (!argument.m_help.empty()) {

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -685,11 +685,11 @@ public:
       }
       prev += pos - prev + 1;
     }
-    if (first_line)
+    if (first_line) {
       stream << "\t" << argument.m_help;
-    else {
+    } else {
       auto leftover = argument.m_help.substr(prev, argument.m_help.size() - prev);
-      if (leftover.size() > 0) {
+      if (!leftover.empty()) {
         stream.width(stream_width);
         stream << std::string(spacing, ' ') << "\t" << leftover;
       }

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -649,7 +649,6 @@ public:
 
   friend std::ostream &operator<<(std::ostream &stream,
                                   const Argument &argument) {
-    auto stream_width = stream.width();
     std::stringstream name_stream;
     name_stream << "  "; // indent
     if (argument.is_positional(argument.m_names.front(),
@@ -669,29 +668,34 @@ public:
         name_stream << " " << argument.m_metavar;
       }
     }
-    auto spacing = name_stream.str().size();
+
+    // align multiline help message
+    auto stream_width = stream.width();
+    auto name_padding = std::string(name_stream.str().size(), ' ');
     auto pos = 0;
     auto prev = 0;
     auto first_line = true;
+    const char* hspace = "  "; // minimal space between name and help message
     stream << name_stream.str();
+    std::string_view help_view(argument.m_help);
     while ((pos = argument.m_help.find('\n', prev)) != std::string::npos) {
-      auto line = argument.m_help.substr(prev, pos - prev + 1);
+      auto line = help_view.substr(prev, pos - prev + 1);
       if (first_line) {
-        stream << "\t" << line;
+        stream << hspace << line;
         first_line = false;
       } else {
         stream.width(stream_width);
-        stream << std::string(spacing, ' ') << "\t" << line;
+        stream << name_padding << hspace << line;
       }
       prev += pos - prev + 1;
     }
     if (first_line) {
-      stream << "\t" << argument.m_help;
+      stream << hspace << argument.m_help;
     } else {
-      auto leftover = argument.m_help.substr(prev, argument.m_help.size() - prev);
+      auto leftover = help_view.substr(prev, argument.m_help.size() - prev);
       if (!leftover.empty()) {
         stream.width(stream_width);
-        stream << std::string(spacing, ' ') << "\t" << leftover;
+        stream << name_padding << hspace << leftover;
       }
     }
 

--- a/test/test_help.cpp
+++ b/test/test_help.cpp
@@ -1,6 +1,8 @@
 #include <argparse/argparse.hpp>
 #include <doctest.hpp>
+#include <regex>
 #include <sstream>
+#include <unordered_map>
 
 using doctest::test_suite;
 
@@ -72,4 +74,58 @@ TEST_CASE("Users can replace default -h/--help" * test_suite("help")) {
   REQUIRE(buffer.str().empty());
   program.parse_args({"test", "--help"});
   REQUIRE_FALSE(buffer.str().empty());
+}
+
+TEST_CASE("Multiline help message alignment") {
+  argparse::ArgumentParser program("program");
+  program.add_argument("input1")
+      .help(
+        "This is the first line of help message.\n"
+        "And this is the second line of help message."
+      );
+  program.add_argument("program_input2")
+      .help("There is only one line.");
+  program.add_argument("-p", "--prog_input3")
+      .help(
+R"(Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+accusantium doloremque laudantium, totam rem aperiam...)"
+      );
+
+  std::ostringstream stream;
+  stream << program;
+  std::string help_text = stream.str();
+
+  // Split the help text into lines
+  std::istringstream iss(help_text);
+  std::vector<std::string> help_lines;
+  std::string line;
+  while (std::getline(iss, line)) {
+    help_lines.push_back(line);
+  }
+
+  // A map to store the starting position of the help text for each argument
+  std::unordered_map<std::string, int> help_start_positions;
+
+  for (const auto& line : help_lines) {
+    // Find the argument names in the line
+    std::smatch match;
+    if (std::regex_search(line, match, std::regex(R"((input1|program_input2|--prog_input3))"))) {
+      std::string arg_name = match.str();
+
+      // Find the position of the first non-space character after the argument name
+      int position = line.find_first_not_of(' ', match.position() + arg_name.size());
+      if (position == std::string::npos) {
+        continue;
+      }
+      help_start_positions[arg_name] = position;
+    }
+  }
+
+  // Check if the positions are the same for all arguments
+  REQUIRE(!help_start_positions.empty());
+  int first_position = help_start_positions.begin()->second;
+  for (const auto& entry : help_start_positions) {
+    REQUIRE(entry.second == first_position);
+  }
 }

--- a/test/test_help.cpp
+++ b/test/test_help.cpp
@@ -1,8 +1,6 @@
 #include <argparse/argparse.hpp>
 #include <doctest.hpp>
-#include <regex>
 #include <sstream>
-#include <unordered_map>
 
 using doctest::test_suite;
 
@@ -77,55 +75,46 @@ TEST_CASE("Users can replace default -h/--help" * test_suite("help")) {
 }
 
 TEST_CASE("Multiline help message alignment") {
+  // '#' is used at the beginning of each help message line to simplify testing.
+  // It is important to ensure that this character doesn't appear elsewhere in the test case.
+  // Default arguments (e.g., -h/--help, -v/--version) are not included in this test.
   argparse::ArgumentParser program("program");
-  program.add_argument("input1")
+  program.add_argument("INPUT1")
       .help(
-        "This is the first line of help message.\n"
-        "And this is the second line of help message."
+        "#This is the first line of help message.\n"
+        "#And this is the second line of help message."
       );
   program.add_argument("program_input2")
-      .help("There is only one line.");
+      .help("#There is only one line.");
   program.add_argument("-p", "--prog_input3")
       .help(
-R"(Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-Sed ut perspiciatis unde omnis iste natus error sit voluptatem
-accusantium doloremque laudantium, totam rem aperiam...)"
+R"(#Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+#Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+#accusantium doloremque laudantium, totam rem aperiam...)"
       );
+  program.add_argument("--verbose").default_value(false).implicit_value(true);
 
   std::ostringstream stream;
   stream << program;
-  std::string help_text = stream.str();
+  std::istringstream iss(stream.str());
 
-  // Split the help text into lines
-  std::istringstream iss(help_text);
-  std::vector<std::string> help_lines;
+  int help_message_start = -1;
   std::string line;
   while (std::getline(iss, line)) {
-    help_lines.push_back(line);
-  }
+    // Find the position of '#', which indicates the start of the help message line
+    auto pos = line.find('#');
 
-  // A map to store the starting position of the help text for each argument
-  std::unordered_map<std::string, int> help_start_positions;
+    if (pos == std::string::npos) {
+      continue;
+    }
 
-  for (const auto& line : help_lines) {
-    // Find the argument names in the line
-    std::smatch match;
-    if (std::regex_search(line, match, std::regex(R"((input1|program_input2|--prog_input3))"))) {
-      std::string arg_name = match.str();
-
-      // Find the position of the first non-space character after the argument name
-      int position = line.find_first_not_of(' ', match.position() + arg_name.size());
-      if (position == std::string::npos) {
-        continue;
-      }
-      help_start_positions[arg_name] = position;
+    if (help_message_start == -1) {
+      help_message_start = pos;
+    } else {
+      REQUIRE(pos == help_message_start);
     }
   }
 
-  // Check if the positions are the same for all arguments
-  REQUIRE(!help_start_positions.empty());
-  int first_position = help_start_positions.begin()->second;
-  for (const auto& entry : help_start_positions) {
-    REQUIRE(entry.second == first_position);
-  }
+  // Make sure we have at least one help message
+  REQUIRE(help_message_start != -1);
 }


### PR DESCRIPTION
This PR fixes #248 by aligning multiline help messages. A previous PR, #259, attempted to fix the issue, but it was not finalized due to unresolved clang-tidy issues. This PR builds upon the work done in PR #259 and addresses the outstanding issues.

The key changes in this PR include:
1. Using spaces instead of `"\t"` to separate argument names and help messages. This makes the spacing independent of the terminal's tab width settings and simplifies testing.
2. Adding a test case to verify that all help messages are properly aligned.

Additionally, while working on this issue, I noticed that the `-DCMAKE_CXX_STANDARD=17` flag is required when using CMake to build the test. This flag is currently not documented in the README:
https://github.com/p-ranav/argparse/blob/557948f1236db9e27089959de837cc23de6c6bbd/README.md?plain=1#L1153-L1160