### PR TITLE
fixing sign compare error

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -683,7 +683,7 @@ public:
     auto hspace = "  "; // minimal space between name and help message
     stream << name_stream.str();
     std::string_view help_view(argument.m_help);
-    while ((pos = argument.m_help.find('\n', prev)) != std::string::npos) {
+    while ((pos = argument.m_help.find('\n', prev)) != (signed)std::string::npos) {
       auto line = help_view.substr(prev, pos - prev + 1);
       if (first_line) {
         stream << hspace << line;


### PR DESCRIPTION
### Before:
./libs/argparse/include/argparse/argparse.hpp: In function ‘std::ostream& argparse::operator<<(std::ostream&, const argparse::Argument&)’:
./libs/argparse/include/argparse/argparse.hpp:686:53: error: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Werror=sign-compare]
  686 |     while ((pos = argument.m_help.find('\n', prev)) != std::string::npos) {
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors

### After:
Build OK