### PR TITLE
Fix behaviour of arguments with default value

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -410,6 +410,7 @@ public:
   }
 
   Argument &default_value(const char *value) {
+    m_num_args_range = NArgsRange{0, m_num_args_range.get_max()};
     return default_value(std::string(value));
   }
 

--- a/test/test_default_value.cpp
+++ b/test/test_default_value.cpp
@@ -4,6 +4,36 @@
 
 using doctest::test_suite;
 
+TEST_CASE("Position of the argument with default value") {
+  argparse::ArgumentParser program("test");
+  program.add_argument("-g").default_value("the_default_value");
+  program.add_argument("-s");
+
+  SUBCASE("Arg with default value not passed") {
+    REQUIRE_NOTHROW(program.parse_args({"test", "-s", "./src"}));
+    REQUIRE(program.get("-g") == std::string("the_default_value"));
+    REQUIRE(program.get("-s") == std::string("./src"));
+  }
+
+  SUBCASE("Arg with default value passed last") {
+    REQUIRE_NOTHROW(program.parse_args({"test", "-s", "./src", "-g"}));
+    REQUIRE(program.get("-g") == std::string("the_default_value"));
+    REQUIRE(program.get("-s") == std::string("./src"));
+  }
+
+  SUBCASE("Arg with default value passed before last") {
+    REQUIRE_NOTHROW(program.parse_args({"test", "-g", "-s", "./src"}));
+    REQUIRE(program.get("-g") == std::string("the_default_value"));
+    REQUIRE(program.get("-s") == std::string("./src"));
+  }
+
+  SUBCASE("Arg with default value replaces the value if given") {
+    REQUIRE_NOTHROW(program.parse_args({"test", "-g", "a_different_value", "-s", "./src"}));
+    REQUIRE(program.get("-g") == std::string("a_different_value"));
+    REQUIRE(program.get("-s") == std::string("./src"));
+  }
+}
+
 TEST_CASE("Use a 'string' default value" * test_suite("default_value")) {
   argparse::ArgumentParser program("test");
 


### PR DESCRIPTION
This is an attempt to fix #287. Might have something to do with #247 as well.

I'm not familiar with this code, so it might break other features, although tests pass locally.