### PR TITLE
Add C++20 module

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,1 @@
+indent_type = "Spaces"

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -72,7 +72,7 @@ struct HasContainerTraits<
                    decltype(std::declval<T>().size())>> : std::true_type {};
 
 template <typename T>
-static constexpr bool IsContainer = HasContainerTraits<T>::value;
+inline constexpr bool IsContainer = HasContainerTraits<T>::value;
 
 template <typename T, typename = void>
 struct HasStreamableTraits : std::false_type {};
@@ -84,7 +84,7 @@ struct HasStreamableTraits<
     : std::true_type {};
 
 template <typename T>
-static constexpr bool IsStreamable = HasStreamableTraits<T>::value;
+inline constexpr bool IsStreamable = HasStreamableTraits<T>::value;
 
 constexpr std::size_t repr_max_container_size = 5;
 

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -29,6 +29,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 #pragma once
+
+#ifndef ARGPARSE_MODULE_USE_STD_MODULE
 #include <algorithm>
 #include <any>
 #include <array>
@@ -53,6 +55,7 @@ SOFTWARE.
 #include <utility>
 #include <variant>
 #include <vector>
+#endif
 
 namespace argparse {
 

--- a/module/argparse.cppm
+++ b/module/argparse.cppm
@@ -29,15 +29,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+module;
+
+#ifndef ARGPARSE_MODULE_USE_STD_MODULE
+#include <argparse/argparse.hpp>
+#endif 
+
 export module argparse;
 
 #ifdef ARGPARSE_MODULE_USE_STD_MODULE
 import std;
-#endif
 
 extern "C++" {
 #include <argparse/argparse.hpp>
 }
+#endif
+
 
 export namespace argparse {
     using argparse::nargs_pattern;

--- a/module/argparse.cppm
+++ b/module/argparse.cppm
@@ -1,0 +1,49 @@
+/*
+  __ _ _ __ __ _ _ __   __ _ _ __ ___  ___
+ / _` | '__/ _` | '_ \ / _` | '__/ __|/ _ \ Argument Parser for Modern C++
+| (_| | | | (_| | |_) | (_| | |  \__ \  __/ http://github.com/p-ranav/argparse
+ \__,_|_|  \__, | .__/ \__,_|_|  |___/\___|
+           |___/|_|
+
+Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+SPDX-License-Identifier: MIT
+Copyright (c) 2019-2022 Pranav Srinivas Kumar <pranav.srinivas.kumar@gmail.com>
+and other contributors.
+
+Permission is hereby  granted, free of charge, to any  person obtaining a copy
+of this software and associated  documentation files (the "Software"), to deal
+in the Software  without restriction, including without  limitation the rights
+to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+module;
+
+#include <argparse/argparse.hpp>
+
+export module argparse;
+
+#ifdef ARGPARSE_MODULE_USE_STD_MODULE
+import std;
+#endif
+
+export namespace argparse {
+    using argparse::nargs_pattern;
+    using argparse::default_arguments;
+    using argparse::operator&;
+    using argparse::Argument;
+    using argparse::ArgumentParser;
+}
+

--- a/module/argparse.cppm
+++ b/module/argparse.cppm
@@ -29,15 +29,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-module;
-
-#include <argparse/argparse.hpp>
-
 export module argparse;
 
 #ifdef ARGPARSE_MODULE_USE_STD_MODULE
 import std;
 #endif
+
+extern "C++" {
+#include <argparse/argparse.hpp>
+}
 
 export namespace argparse {
     using argparse::nargs_pattern;

--- a/test/argparse_details.cppm
+++ b/test/argparse_details.cppm
@@ -1,0 +1,10 @@
+module;
+
+#include <argparse/argparse.hpp>
+
+export module argparse.details;
+
+export namespace argparse::details {
+    using argparse::details::repr;
+}
+

--- a/test/test_actions.cpp
+++ b/test/test_actions.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 
 using doctest::test_suite;

--- a/test/test_append.cpp
+++ b/test/test_append.cpp
@@ -1,5 +1,12 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
+
+#include <vector>
+#include <string>
 
 using doctest::test_suite;
 

--- a/test/test_as_container.cpp
+++ b/test/test_as_container.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 
 using doctest::test_suite;

--- a/test/test_bool_operator.cpp
+++ b/test/test_bool_operator.cpp
@@ -1,4 +1,9 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
+
 #include <doctest.hpp>
 
 using doctest::test_suite;

--- a/test/test_compound_arguments.cpp
+++ b/test/test_compound_arguments.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 #include <test_utility.hpp>
 

--- a/test/test_const_correct.cpp
+++ b/test/test_const_correct.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 
 using doctest::test_suite;

--- a/test/test_container_arguments.cpp
+++ b/test/test_container_arguments.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 #include <test_utility.hpp>
 

--- a/test/test_default_args.cpp
+++ b/test/test_default_args.cpp
@@ -1,7 +1,13 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
+
 #include <sstream>
 #include <streambuf>
+#include <iostream>
 
 using doctest::test_suite;
 

--- a/test/test_default_value.cpp
+++ b/test/test_default_value.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 #include <string>
 

--- a/test/test_equals_form.cpp
+++ b/test/test_equals_form.cpp
@@ -1,6 +1,14 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
+
 #include <iostream>
+#include <vector>
+#include <string>
+
 using doctest::test_suite;
 
 TEST_CASE("Basic --value=value" * test_suite("equals_form")) {

--- a/test/test_get.cpp
+++ b/test/test_get.cpp
@@ -1,5 +1,11 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
+
+#include <any>
 
 using doctest::test_suite;
 

--- a/test/test_help.cpp
+++ b/test/test_help.cpp
@@ -1,6 +1,12 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
+
 #include <sstream>
+#include <optional>
 
 using doctest::test_suite;
 

--- a/test/test_invalid_arguments.cpp
+++ b/test/test_invalid_arguments.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 
 using doctest::test_suite;

--- a/test/test_is_used.cpp
+++ b/test/test_is_used.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 
 using doctest::test_suite;

--- a/test/test_issue_37.cpp
+++ b/test/test_issue_37.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 
 using doctest::test_suite;

--- a/test/test_negative_numbers.cpp
+++ b/test/test_negative_numbers.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 
 using doctest::test_suite;

--- a/test/test_optional_arguments.cpp
+++ b/test/test_optional_arguments.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 
 using doctest::test_suite;

--- a/test/test_parent_parsers.cpp
+++ b/test/test_parent_parsers.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 
 using doctest::test_suite;

--- a/test/test_parse_args.cpp
+++ b/test/test_parse_args.cpp
@@ -1,5 +1,11 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
+
+#include <optional>
 
 using doctest::test_suite;
 

--- a/test/test_parse_known_args.cpp
+++ b/test/test_parse_known_args.cpp
@@ -1,5 +1,12 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
+
+#include <vector>
+#include <string>
 
 using doctest::test_suite;
 

--- a/test/test_positional_arguments.cpp
+++ b/test/test_positional_arguments.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <cmath>
 #include <doctest.hpp>
 

--- a/test/test_prefix_chars.cpp
+++ b/test/test_prefix_chars.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <cmath>
 #include <doctest.hpp>
 

--- a/test/test_repr.cpp
+++ b/test/test_repr.cpp
@@ -1,6 +1,14 @@
+#ifdef WITH_MODULE
+import argparse;
+import argparse.details;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
+
 #include <set>
+#include <list>
+#include <sstream>
 
 using doctest::test_suite;
 

--- a/test/test_required_arguments.cpp
+++ b/test/test_required_arguments.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 
 using doctest::test_suite;

--- a/test/test_scan.cpp
+++ b/test/test_scan.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 #include <stdint.h>
 

--- a/test/test_subparsers.cpp
+++ b/test/test_subparsers.cpp
@@ -1,6 +1,13 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
-#include <cmath>
+#endif
 #include <doctest.hpp>
+
+#include <cmath>
+#include <vector>
+#include <string>
 
 using doctest::test_suite;
 

--- a/test/test_utility.hpp
+++ b/test/test_utility.hpp
@@ -1,6 +1,8 @@
 #ifndef ARGPARSE_TEST_UTILITY_HPP
 #define ARGPARSE_TEST_UTILITY_HPP
 
+#include <list>
+
 namespace testutility {
 // Get value at index from std::list
 template <typename T>

--- a/test/test_value_semantics.cpp
+++ b/test/test_value_semantics.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 
 using doctest::test_suite;

--- a/test/test_version.cpp
+++ b/test/test_version.cpp
@@ -1,4 +1,8 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
 #include <argparse/argparse.hpp>
+#endif
 #include <doctest.hpp>
 #include <sstream>
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -44,7 +44,7 @@ if get_config("enable_tests") then
     do
         set_kind("binary")
         set_languages("c++17")
-        set_basename("module_tests")
+        set_basename("tests")
 
         add_includedirs("test")
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -22,8 +22,7 @@ if is_plat("windows") then
     add_defines("_CRT_SECURE_NO_WARNINGS")
 end
 
-target("argparse")
-do
+target("argparse", function()
     if get_config("enable_module") then
         set_languages("c++20")
         set_kind("object")
@@ -37,11 +36,10 @@ do
     if get_config("enable_module") then
         add_files("module/argparse.cppm", { install = true })
     end
-end
+end)
 
 if get_config("enable_tests") then
-    target("argparse_tests")
-    do
+    target("argparse_tests", function()
         set_kind("binary")
         set_languages("c++17")
         set_basename("tests")
@@ -52,11 +50,10 @@ if get_config("enable_tests") then
         add_files("test/**.cpp")
 
         add_deps("argparse")
-    end
+    end)
 
     if get_config("enable_module") then
-        target("argparse_module_tests")
-        do
+        target("argparse_module_tests", function()
             set_kind("binary")
             set_languages("c++20")
             set_basename("module_tests")
@@ -70,14 +67,13 @@ if get_config("enable_tests") then
             add_files("test/argparse_details.cppm")
 
             add_deps("argparse")
-        end
+        end)
     end
 end
 
 if get_config("enable_samples") then
     for _, sample_file in ipairs(os.files("samples/*.cpp")) do
-        target(path.basename(sample_file))
-        do
+        target(path.basename(sample_file), function()
             set_kind("binary")
             set_languages("c++17")
 
@@ -86,6 +82,6 @@ if get_config("enable_samples") then
             set_policy("build.c++.modules", false)
 
             add_deps("argparse")
-        end
+        end)
     end
 end

--- a/xmake.lua
+++ b/xmake.lua
@@ -8,84 +8,84 @@ option("enable_tests")
 option("enable_samples")
 
 add_cxxflags(
-	"-Wall",
-	"-Wno-long-long",
-	"-pedantic",
-	"-Wsign-conversion",
-	"-Wshadow",
-	"-Wconversion",
-	{ toolsets = { "clang", "gcc" } }
+    "-Wall",
+    "-Wno-long-long",
+    "-pedantic",
+    "-Wsign-conversion",
+    "-Wshadow",
+    "-Wconversion",
+    { toolsets = { "clang", "gcc" } }
 )
 add_cxxflags("cl::/W4")
 
 if is_plat("windows") then
-	add_defines("_CRT_SECURE_NO_WARNINGS")
+    add_defines("_CRT_SECURE_NO_WARNINGS")
 end
 
 target("argparse")
 do
-	if get_config("enable_module") then
-		set_languages("c++20")
-		set_kind("object")
-	else
-		set_languages("c++17")
-		set_kind("headeronly")
-	end
+    if get_config("enable_module") then
+        set_languages("c++20")
+        set_kind("object")
+    else
+        set_languages("c++17")
+        set_kind("headeronly")
+    end
 
-	add_includedirs("include", { public = true })
-	add_headerfiles("include/argparse/argparse.hpp")
-	if get_config("enable_module") then
-		add_files("module/argparse.cppm", { install = true })
-	end
+    add_includedirs("include", { public = true })
+    add_headerfiles("include/argparse/argparse.hpp")
+    if get_config("enable_module") then
+        add_files("module/argparse.cppm", { install = true })
+    end
 end
 
 if get_config("enable_tests") then
-	target("argparse_tests")
-	do
-		set_kind("binary")
-		set_languages("c++17")
-		set_basename("module_tests")
+    target("argparse_tests")
+    do
+        set_kind("binary")
+        set_languages("c++17")
+        set_basename("module_tests")
 
-		add_includedirs("test")
+        add_includedirs("test")
 
-		add_files("test/main.cpp", { defines = { "DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN" } })
-		add_files("test/**.cpp")
+        add_files("test/main.cpp", { defines = { "DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN" } })
+        add_files("test/**.cpp")
 
-		add_deps("argparse")
-	end
+        add_deps("argparse")
+    end
 
-	if get_config("enable_module") then
-		target("argparse_module_tests")
-		do
-			set_kind("binary")
-			set_languages("c++20")
-			set_basename("module_tests")
+    if get_config("enable_module") then
+        target("argparse_module_tests")
+        do
+            set_kind("binary")
+            set_languages("c++20")
+            set_basename("module_tests")
 
-			add_defines("WITH_MODULE")
+            add_defines("WITH_MODULE")
 
-			add_includedirs("test")
+            add_includedirs("test")
 
-			add_files("test/main.cpp", { defines = { "DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN" } })
-			add_files("test/**.cpp")
-			add_files("test/argparse_details.cppm")
+            add_files("test/main.cpp", { defines = { "DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN" } })
+            add_files("test/**.cpp")
+            add_files("test/argparse_details.cppm")
 
-			add_deps("argparse")
-		end
-	end
+            add_deps("argparse")
+        end
+    end
 end
 
 if get_config("enable_samples") then
-	for _, sample_file in ipairs(os.files("samples/*.cpp")) do
-			target(path.basename(sample_file))
-			do
-				set_kind("binary")
-				set_languages("c++17")
+    for _, sample_file in ipairs(os.files("samples/*.cpp")) do
+        target(path.basename(sample_file))
+        do
+            set_kind("binary")
+            set_languages("c++17")
 
-				add_files(sample_file)
+            add_files(sample_file)
 
-        set_policy("build.c++.modules", false)
+            set_policy("build.c++.modules", false)
 
-				add_deps("argparse")
-			end
-	end
+            add_deps("argparse")
+        end
+    end
 end

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,91 @@
+set_xmakever("2.8.2")
+set_project("argparse")
+
+set_version("2.9.0", { build = "%Y%m%d%H%M" })
+
+option("enable_module")
+option("enable_tests")
+option("enable_samples")
+
+add_cxxflags(
+	"-Wall",
+	"-Wno-long-long",
+	"-pedantic",
+	"-Wsign-conversion",
+	"-Wshadow",
+	"-Wconversion",
+	{ toolsets = { "clang", "gcc" } }
+)
+add_cxxflags("cl::/W4")
+
+if is_plat("windows") then
+	add_defines("_CRT_SECURE_NO_WARNINGS")
+end
+
+target("argparse")
+do
+	if get_config("enable_module") then
+		set_languages("c++20")
+		set_kind("object")
+	else
+		set_languages("c++17")
+		set_kind("headeronly")
+	end
+
+	add_includedirs("include", { public = true })
+	add_headerfiles("include/argparse/argparse.hpp")
+	if get_config("enable_module") then
+		add_files("module/argparse.cppm", { install = true })
+	end
+end
+
+if get_config("enable_tests") then
+	target("argparse_tests")
+	do
+		set_kind("binary")
+		set_languages("c++17")
+		set_basename("module_tests")
+
+		add_includedirs("test")
+
+		add_files("test/main.cpp", { defines = { "DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN" } })
+		add_files("test/**.cpp")
+
+		add_deps("argparse")
+	end
+
+	if get_config("enable_module") then
+		target("argparse_module_tests")
+		do
+			set_kind("binary")
+			set_languages("c++20")
+			set_basename("module_tests")
+
+			add_defines("WITH_MODULE")
+
+			add_includedirs("test")
+
+			add_files("test/main.cpp", { defines = { "DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN" } })
+			add_files("test/**.cpp")
+			add_files("test/argparse_details.cppm")
+
+			add_deps("argparse")
+		end
+	end
+end
+
+if get_config("enable_samples") then
+	for _, sample_file in ipairs(os.files("samples/*.cpp")) do
+			target(path.basename(sample_file))
+			do
+				set_kind("binary")
+				set_languages("c++17")
+
+				add_files(sample_file)
+
+        set_policy("build.c++.modules", false)
+
+				add_deps("argparse")
+			end
+	end
+end

--- a/xmake.lua
+++ b/xmake.lua
@@ -23,13 +23,12 @@ if is_plat("windows") then
 end
 
 target("argparse", function()
+    set_languages("c++17")
+    set_kind("headeronly")
     if get_config("enable_module") then
         set_languages("c++20")
-        set_kind("object")
+        set_kind("static") -- static atm because of a XMake bug, headeronly doesn't generate package module metadata
     else
-        set_languages("c++17")
-        set_kind("headeronly")
-    end
 
     add_includedirs("include", { public = true })
     add_headerfiles("include/argparse/argparse.hpp")

--- a/xmake.lua
+++ b/xmake.lua
@@ -4,6 +4,7 @@ set_project("argparse")
 set_version("2.9.0", { build = "%Y%m%d%H%M" })
 
 option("enable_module")
+option("enable_std_import", { defines = "ARGPARSE_MODULE_USE_STD_MODULE" })
 option("enable_tests")
 option("enable_samples")
 
@@ -28,7 +29,9 @@ target("argparse", function()
     if get_config("enable_module") then
         set_languages("c++20")
         set_kind("static") -- static atm because of a XMake bug, headeronly doesn't generate package module metadata
-    else
+    end
+
+    add_options("enable_std_import")
 
     add_includedirs("include", { public = true })
     add_headerfiles("include/argparse/argparse.hpp")


### PR DESCRIPTION
This PR add a C++20 module, enable tests with the module when WITH_MODULE define is set
and add xmake build system support (mainly to test module compilation, it's easier to write and use than CMake module support and i'm not a CMake user / expert) 

the ARGPARSE_MODULE_USE_STD_MODULE can be set to remove #include of std lib for user that want to use C++23 std module
we need this because mixing #include \<stdheader\> / import \<stdheader\> with C++23 std module doesn't work well atm on clang/GCC/msvc

to try it

install xmake: https://xmake.io/#/guide/installation

```
> xmake f --enable_tests=y --enable_module=y --enable_samples=y
> xmake b
> xmake run argparse_tests
> xmake run argparse_module_tests
> xmake run <sample_name>
```