### PR TITLE
CMakefile: Use -Wpedantic, -Werror and -Wextra for compilation in gcc. Fixed warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(argparse
 )
 
 option(ARGPARSE_INSTALL "Include an install target" ON)
-option(ARGPARSE_BUILD_TESTS "Build tests" OFF)
+option(ARGPARSE_BUILD_TESTS "Build tests" ON)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -680,8 +680,8 @@ public:
     // align multiline help message
     auto stream_width = stream.width();
     auto name_padding = std::string(name_stream.str().size(), ' ');
-    auto pos = 0;
-    auto prev = 0;
+    auto pos = std::string::size_type{};
+    auto prev = std::string::size_type{};
     auto first_line = true;
     auto hspace = "  "; // minimal space between name and help message
     stream << name_stream.str();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ if(MSVC)
   endif()
 elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
   # Update if necessary
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic -Wsign-conversion -Wshadow -Wconversion")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -Wpedantic -Wsign-conversion -Wshadow -Wconversion -Werror -Wextra")
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/test/test_help.cpp
+++ b/test/test_help.cpp
@@ -104,7 +104,7 @@ R"(#Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   stream << program;
   std::istringstream iss(stream.str());
 
-  int help_message_start = -1;
+  auto help_message_start = std::string::npos;
   std::string line;
   while (std::getline(iss, line)) {
     // Find the position of '#', which indicates the start of the help message line
@@ -114,7 +114,7 @@ R"(#Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       continue;
     }
 
-    if (help_message_start == -1) {
+    if (help_message_start == std::string::npos) {
       help_message_start = pos;
     } else {
       REQUIRE(pos == help_message_start);


### PR DESCRIPTION
CMakefile: Use -Wpedantic, -Werror and -Wextra for compilation in gcc. Fixed warnings