### PR TITLE
Add to readme cmake FetchContent section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1133,6 +1133,8 @@ PROJECT(myproject)
 
 # fetch latest argparse
 include(FetchContent)
+set(ARGPARSE_BUILD_TESTS OFF CACHE INTERNAL "Turn off building argparse tests")
+set(ARGPARSE_BUILD_SAMPLES OFF CACHE INTERNAL "Turn off building argparse samples")
 FetchContent_Declare(
     argparse
     GIT_REPOSITORY https://github.com/p-ranav/argparse.git


### PR DESCRIPTION
It's imporant to note that FetchContent will automatically build all of the argparse tests and samples when including it with FetchContent, since the root CMakeLists.txt file sets these options as ON by default.

Generally, users of the library wouldn't want tests and samples to be built alongside a library dependency, so we could include these two more lines in the README to show how to disable building the tests and samples by default.