### PR TITLE
Change parse_args readme and samples to catch const std::exception&

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ int main(int argc, char *argv[]) {
   try {
     program.parse_args(argc, argv);
   }
-  catch (const std::runtime_error& err) {
+  catch (const std::exception& err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;
@@ -137,7 +137,7 @@ program.add_argument("--verbose")
 try {
   program.parse_args(argc, argv);
 }
-catch (const std::runtime_error& err) {
+catch (const std::exception& err) {
   std::cerr << err.what() << std::endl;
   std::cerr << program;
   std::exit(1);
@@ -203,7 +203,7 @@ program.add_argument("--color")
 try {
   program.parse_args(argc, argv);    // Example: ./main --color orange
 }
-catch (const std::runtime_error& err) {
+catch (const std::exception& err) {
   std::cerr << err.what() << std::endl;
   std::cerr << program;
   std::exit(1);
@@ -226,7 +226,7 @@ program.add_argument("--color")
 try {
   program.parse_args(argc, argv);    // Example: ./main --color red --color green --color blue
 }
-catch (const std::runtime_error& err) {
+catch (const std::exception& err) {
   std::cerr << err.what() << std::endl;
   std::cerr << program;
   std::exit(1);
@@ -274,7 +274,7 @@ program.add_argument("floats")
 try {
   program.parse_args(argc, argv);
 }
-catch (const std::runtime_error& err) {
+catch (const std::exception& err) {
   std::cerr << err.what() << std::endl;
   std::cerr << program;
   std::exit(1);
@@ -307,7 +307,7 @@ program.add_argument("--verbose")
 try {
   program.parse_args(argc, argv);
 }
-catch (const std::runtime_error& err) {
+catch (const std::exception& err) {
   std::cerr << err.what() << std::endl;
   std::cerr << program;
   std::exit(1);
@@ -407,7 +407,7 @@ program.add_argument("--input_files")
 try {
   program.parse_args(argc, argv);   // Example: ./main --input_files config.yml System.xml
 }
-catch (const std::runtime_error& err) {
+catch (const std::exception& err) {
   std::cerr << err.what() << std::endl;
   std::cerr << program;
   std::exit(1);
@@ -436,7 +436,7 @@ program.add_argument("--query_point")
 try {
   program.parse_args(argc, argv); // Example: ./main --query_point 3.5 4.7 9.2
 }
-catch (const std::runtime_error& err) {
+catch (const std::exception& err) {
   std::cerr << err.what() << std::endl;
   std::cerr << program;
   std::exit(1);
@@ -491,7 +491,7 @@ program.add_argument("-c")
 try {
   program.parse_args(argc, argv);                  // Example: ./main -abc 1.95 2.47
 }
-catch (const std::runtime_error& err) {
+catch (const std::exception& err) {
   std::cerr << err.what() << std::endl;
   std::cerr << program;
   std::exit(1);
@@ -604,7 +604,7 @@ program.add_argument("files")
 try {
   program.parse_args(argc, argv);
 }
-catch (const std::runtime_error& err) {
+catch (const std::exception& err) {
   std::cerr << err.what() << std::endl;
   std::cerr << program;
   std::exit(1);
@@ -651,7 +651,7 @@ program.add_argument("files")
 try {
   program.parse_args(argc, argv);
 }
-catch (const std::runtime_error& err) {
+catch (const std::exception& err) {
   std::cerr << err.what() << std::endl;
   std::cerr << program;
   std::exit(1);
@@ -777,7 +777,7 @@ int main(int argc, char *argv[]) {
   try {
     program.parse_args(argc, argv);
   }
-  catch (const std::runtime_error& err) {
+  catch (const std::exception& err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;
@@ -904,7 +904,7 @@ int main(int argc, char *argv[]) {
   try {
     program.parse_args(argc, argv);
   }
-  catch (const std::runtime_error& err) {
+  catch (const std::exception& err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;
@@ -952,7 +952,7 @@ int main(int argc, char *argv[]) {
   try {
     program.parse_args(argc, argv);
   }
-  catch (const std::runtime_error& err) {
+  catch (const std::exception& err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;
@@ -993,7 +993,7 @@ program.add_argument("config")
 try {
   program.parse_args({"./test", "config.json"});
 }
-catch (const std::runtime_error& err) {
+catch (const std::exception& err) {
   std::cerr << err.what() << std::endl;
   std::cerr << program;
   std::exit(1);
@@ -1029,7 +1029,7 @@ program.add_argument("--files")
 try {
   program.parse_args(argc, argv);
 }
-catch (const std::runtime_error& err) {
+catch (const std::exception& err) {
   std::cerr << err.what() << std::endl;
   std::cerr << program;
   std::exit(1);
@@ -1071,7 +1071,7 @@ program.add_argument("input")
 try {
   program.parse_args(argc, argv);
 }
-catch (const std::runtime_error& err) {
+catch (const std::exception& err) {
   std::cerr << err.what() << std::endl;
   std::cerr << program;
   std::exit(1);
@@ -1100,7 +1100,7 @@ int main(int argc, char *argv[]) {
   try {
     program.parse_args(argc, argv);
   }
-  catch (const std::runtime_error& err) {
+  catch (const std::exception& err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;

--- a/samples/compound_arguments.cpp
+++ b/samples/compound_arguments.cpp
@@ -16,7 +16,7 @@ int main(int argc, char *argv[]) {
 
   try {
     program.parse_args(argc, argv); // Example: ./main -abc 1.95 2.47
-  } catch (const std::runtime_error &err) {
+  } catch (const std::exception &err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;

--- a/samples/custom_assignment_characters.cpp
+++ b/samples/custom_assignment_characters.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[]) {
 
   try {
     program.parse_args(argc, argv);
-  } catch (const std::runtime_error &err) {
+  } catch (const std::exception &err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;

--- a/samples/custom_prefix_characters.cpp
+++ b/samples/custom_prefix_characters.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[]) {
 
   try {
     program.parse_args(argc, argv);
-  } catch (const std::runtime_error &err) {
+  } catch (const std::exception &err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;

--- a/samples/gathering_remaining_arguments.cpp
+++ b/samples/gathering_remaining_arguments.cpp
@@ -9,7 +9,7 @@ int main(int argc, char *argv[]) {
 
   try {
     program.parse_args(argc, argv);
-  } catch (const std::runtime_error &err) {
+  } catch (const std::exception &err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;

--- a/samples/is_used.cpp
+++ b/samples/is_used.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[]) {
 
   try {
     program.parse_args(argc, argv); // Example: ./main --color orange
-  } catch (const std::runtime_error &err) {
+  } catch (const std::exception &err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;

--- a/samples/joining_repeated_optional_arguments.cpp
+++ b/samples/joining_repeated_optional_arguments.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[]) {
   try {
     program.parse_args(
         argc, argv); // Example: ./main --color red --color green --color blue
-  } catch (const std::runtime_error &err) {
+  } catch (const std::exception &err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;

--- a/samples/list_of_arguments.cpp
+++ b/samples/list_of_arguments.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[]) {
   try {
     program.parse_args(
         argc, argv); // Example: ./main --input_files config.yml System.xml
-  } catch (const std::runtime_error &err) {
+  } catch (const std::exception &err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;

--- a/samples/negative_numbers.cpp
+++ b/samples/negative_numbers.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[]) {
 
   try {
     program.parse_args(argc, argv);
-  } catch (const std::runtime_error &err) {
+  } catch (const std::exception &err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;

--- a/samples/optional_flag_argument.cpp
+++ b/samples/optional_flag_argument.cpp
@@ -12,7 +12,7 @@ int main(int argc, char *argv[]) {
 
   try {
     program.parse_args(argc, argv);
-  } catch (const std::runtime_error &err) {
+  } catch (const std::exception &err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;

--- a/samples/positional_argument.cpp
+++ b/samples/positional_argument.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[]) {
 
   try {
     program.parse_args(argc, argv);
-  } catch (const std::runtime_error &err) {
+  } catch (const std::exception &err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;

--- a/samples/required_optional_argument.cpp
+++ b/samples/required_optional_argument.cpp
@@ -11,7 +11,7 @@ int main(int argc, char *argv[]) {
 
   try {
     program.parse_args(argc, argv);
-  } catch (const std::runtime_error &err) {
+  } catch (const std::exception &err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;

--- a/samples/subcommands.cpp
+++ b/samples/subcommands.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) {
 
   try {
     program.parse_args(argc, argv);
-  } catch (const std::runtime_error &err) {
+  } catch (const std::exception &err) {
     std::cerr << err.what() << std::endl;
     std::cerr << program;
     return 1;


### PR DESCRIPTION
parse_args can throw exceptions that are not based on std::runtime_error, and the error message should show on all errors.

For example, if a user is using a program formatted as:

```cpp
parser.add_argument("number")
    .help("Enter a number")
    .scan<'i', int>();

try {
    parser.parse_args(argc, argv);
} catch (const std::runtime_error &e) {
    std::cerr << e.what() << std::endl;
    std::cerr << parser;
    return EXIT_FAILURE;
}
```

and the user messes up by misformatting the "number" positional argument, this will throw an std::invalid_argument from argparse::details::do_from_chars. However, [std::invalid_argument inherits from std::logic_error, not std::runtime_error](https://en.cppreference.com/w/cpp/error/invalid_argument), so the user will just have an aborted program with no help message. In order to keep the code simple while not having to catch std::runtime_error and std::logic_error separately, the user could use std::exception instead to catch all errors of parse_args.