### PR TITLE
Closes #277

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,7 +1080,7 @@ foo@bar:/home/dev/$ ./main fex
 Invalid argument "fex" - allowed options: {foo, bar, baz}
 ```
 
-Using choices also works in integer types, e.g.,
+Using choices also works with integer types, e.g.,
 
 ```cpp
 argparse::ArgumentParser program("test");

--- a/README.md
+++ b/README.md
@@ -1060,13 +1060,7 @@ argparse::ArgumentParser program("test");
 
 program.add_argument("input")
   .default_value(std::string{"baz"})
-  .action([](const std::string& value) {
-    static const std::vector<std::string> choices = { "foo", "bar", "baz" };
-    if (std::find(choices.begin(), choices.end(), value) != choices.end()) {
-      return value;
-    }
-    return std::string{ "baz" };
-  });
+  .choices("foo", "bar", "baz");
 
 try {
   program.parse_args(argc, argv);
@@ -1083,7 +1077,34 @@ std::cout << input << std::endl;
 
 ```console
 foo@bar:/home/dev/$ ./main fex
-baz
+Invalid argument "fex" - allowed options: {foo, bar, baz}
+```
+
+Using choices also works in integer types, e.g.,
+
+```cpp
+argparse::ArgumentParser program("test");
+
+program.add_argument("input")
+  .default_value(0)
+  .choices(0, 1, 2, 3, 4, 5);
+
+try {
+  program.parse_args(argc, argv);
+}
+catch (const std::exception& err) {
+  std::cerr << err.what() << std::endl;
+  std::cerr << program;
+  std::exit(1);
+}
+
+auto input = program.get("input");
+std::cout << input << std::endl;
+```
+
+```console
+foo@bar:/home/dev/$ ./main 6
+Invalid argument "6" - allowed options: {0, 1, 2, 3, 4, 5}
 ```
 
 ## Using `option=value` syntax

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -361,6 +361,15 @@ struct can_invoke_to_string {
   static constexpr bool value = decltype(test<T>(0))::value;
 };
 
+template <typename T>
+struct is_choice_type_supported {
+    using CleanType = typename std::decay<T>::type;
+    static const bool value = std::is_integral<CleanType>::value ||
+        std::is_same<CleanType, std::string>::value ||
+        std::is_same<CleanType, std::string_view>::value ||
+        std::is_same<CleanType, const char*>::value;
+};
+
 } // namespace details
 
 enum class nargs_pattern { optional, any, at_least_one };
@@ -546,6 +555,7 @@ public:
 
   template <typename T>
   void add_choice(T&& choice) {
+    static_assert(details::is_choice_type_supported<T>::value, "Only string or integer type supported for choice");
     static_assert(std::is_convertible_v<T, std::string_view> || details::can_invoke_to_string<T>::value, "Choice is not convertible to string_type");
     if (!m_choices.has_value()) {
       m_choices = std::vector<std::string>{};

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -362,7 +362,7 @@ struct can_invoke_to_string {
 };
 
 template <typename T>
-struct is_choice_type_supported {
+struct IsChoiceTypeSupported {
     using CleanType = typename std::decay<T>::type;
     static const bool value = std::is_integral<CleanType>::value ||
         std::is_same<CleanType, std::string>::value ||
@@ -555,7 +555,7 @@ public:
 
   template <typename T>
   void add_choice(T&& choice) {
-    static_assert(details::is_choice_type_supported<T>::value, "Only string or integer type supported for choice");
+    static_assert(details::IsChoiceTypeSupported<T>::value, "Only string or integer type supported for choice");
     static_assert(std::is_convertible_v<T, std::string_view> || details::can_invoke_to_string<T>::value, "Choice is not convertible to string_type");
     if (!m_choices.has_value()) {
       m_choices = std::vector<std::string>{};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ file(GLOB ARGPARSE_TEST_SOURCES
     test_append.cpp
     test_as_container.cpp
     test_bool_operator.cpp
+    test_choices.cpp
     test_compound_arguments.cpp
     test_container_arguments.cpp
     test_const_correct.cpp

--- a/test/test_append.cpp
+++ b/test/test_append.cpp
@@ -5,8 +5,8 @@ import argparse;
 #endif
 #include <doctest.hpp>
 
-#include <vector>
 #include <string>
+#include <vector>
 
 using doctest::test_suite;
 

--- a/test/test_as_container.cpp
+++ b/test/test_as_container.cpp
@@ -28,8 +28,8 @@ TEST_CASE("Get argument with .at()" * test_suite("as_container")) {
 
   SUBCASE("with unknown argument") {
     program.parse_args({"test"});
-    REQUIRE_THROWS_WITH_AS(program.at("--folder"),
-                           "No such argument: --folder", std::logic_error);
+    REQUIRE_THROWS_WITH_AS(program.at("--folder"), "No such argument: --folder",
+                           std::logic_error);
   }
 }
 
@@ -44,7 +44,8 @@ TEST_CASE("Get subparser with .at()" * test_suite("as_container")) {
   SUBCASE("and its argument") {
     program.parse_args({"test", "walk", "4km/h"});
     REQUIRE(&(program.at<argparse::ArgumentParser>("walk")) == &walk_cmd);
-    REQUIRE(&(program.at<argparse::ArgumentParser>("walk").at("speed")) == &speed);
+    REQUIRE(&(program.at<argparse::ArgumentParser>("walk").at("speed")) ==
+            &speed);
     REQUIRE(program.at<argparse::ArgumentParser>("walk").is_used("speed"));
   }
 

--- a/test/test_bool_operator.cpp
+++ b/test/test_bool_operator.cpp
@@ -8,8 +8,7 @@ import argparse;
 
 using doctest::test_suite;
 
-TEST_CASE("ArgumentParser in bool context" *
-          test_suite("argument_parser")) {
+TEST_CASE("ArgumentParser in bool context" * test_suite("argument_parser")) {
   argparse::ArgumentParser program("test");
   program.add_argument("cases").remaining();
 
@@ -39,7 +38,7 @@ TEST_CASE("With subparsers in bool context" * test_suite("argument_parser")) {
 }
 
 TEST_CASE("Parsers remain false with unknown arguments" *
-           test_suite("argument_parser")) {
+          test_suite("argument_parser")) {
   argparse::ArgumentParser program("test");
 
   argparse::ArgumentParser cmd_build("build");
@@ -59,7 +58,7 @@ TEST_CASE("Parsers remain false with unknown arguments" *
 }
 
 TEST_CASE("Multi-level parsers match subparser bool" *
-           test_suite("argument_parser")) {
+          test_suite("argument_parser")) {
   argparse::ArgumentParser program("test");
 
   argparse::ArgumentParser cmd_cook("cook");

--- a/test/test_choices.cpp
+++ b/test/test_choices.cpp
@@ -1,0 +1,70 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
+#include <argparse/argparse.hpp>
+#endif
+
+#include <doctest.hpp>
+
+using doctest::test_suite;
+
+TEST_CASE("Parse argument that is provided zero choices" *
+          test_suite("choices")) {
+  argparse::ArgumentParser program("test");
+  REQUIRE_THROWS_WITH_AS(program.add_argument("color").choices(),
+                         "Zero choices provided", std::runtime_error);
+}
+
+TEST_CASE("Parse argument that is in the fixed number of allowed choices" *
+          test_suite("choices")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("color").choices("red", "green", "blue");
+
+  program.parse_args({"test", "red"});
+}
+
+TEST_CASE("Parse argument that is in the fixed number of allowed choices, with "
+          "invalid default" *
+          test_suite("choices")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("color").default_value("yellow").choices("red", "green",
+                                                                "blue");
+
+  REQUIRE_THROWS_WITH_AS(
+      program.parse_args({"test"}),
+      "Invalid default value \"yellow\" - allowed options: {red, green, blue}",
+      std::runtime_error);
+}
+
+TEST_CASE("Parse invalid argument that is not in the fixed number of allowed "
+          "choices" *
+          test_suite("choices")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("color").choices("red", "green", "blue");
+
+  REQUIRE_THROWS_WITH_AS(
+      program.parse_args({"test", "red2"}),
+      "Invalid argument \"red2\" - allowed options: {red, green, blue}",
+      std::runtime_error);
+}
+
+TEST_CASE(
+    "Parse multiple arguments that are in the fixed number of allowed choices" *
+    test_suite("choices")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("color").nargs(2).choices("red", "green", "blue");
+
+  program.parse_args({"test", "red", "green"});
+}
+
+TEST_CASE("Parse multiple arguments one of which is not in the fixed number of "
+          "allowed choices" *
+          test_suite("choices")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("color").nargs(2).choices("red", "green", "blue");
+
+  REQUIRE_THROWS_WITH_AS(
+      program.parse_args({"test", "red", "green2"}),
+      "Invalid argument \"green2\" - allowed options: {red, green, blue}",
+      std::runtime_error);
+}

--- a/test/test_choices.cpp
+++ b/test/test_choices.cpp
@@ -68,3 +68,24 @@ TEST_CASE("Parse multiple arguments one of which is not in the fixed number of "
       "Invalid argument \"green2\" - allowed options: {red, green, blue}",
       std::runtime_error);
 }
+
+TEST_CASE(
+    "Parse multiple arguments that are in the fixed number of allowed INTEGER choices" *
+    test_suite("choices")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("indices").nargs(2).choices(1, 2, 3, 4, 5);
+
+  program.parse_args({"test", "1", "2"});
+}
+
+TEST_CASE(
+    "Parse multiple arguments that are not in fixed number of allowed INTEGER choices" *
+    test_suite("choices")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("indices").nargs(2).choices(1, 2, 3, 4, 5);
+
+  REQUIRE_THROWS_WITH_AS(
+      program.parse_args({"test", "6", "7"}),
+      "Invalid argument \"6\" - allowed options: {1, 2, 3, 4, 5}",
+      std::runtime_error);
+}

--- a/test/test_default_args.cpp
+++ b/test/test_default_args.cpp
@@ -5,9 +5,9 @@ import argparse;
 #endif
 #include <doctest.hpp>
 
+#include <iostream>
 #include <sstream>
 #include <streambuf>
-#include <iostream>
 
 using doctest::test_suite;
 
@@ -30,7 +30,7 @@ TEST_CASE("Do not exit on default arguments" * test_suite("default_args")) {
   argparse::ArgumentParser parser("test", "1.0",
                                   argparse::default_arguments::all, false);
   std::stringstream buf;
-  std::streambuf* saved_cout_buf = std::cout.rdbuf(buf.rdbuf());
+  std::streambuf *saved_cout_buf = std::cout.rdbuf(buf.rdbuf());
   parser.parse_args({"test", "--help"});
   std::cout.rdbuf(saved_cout_buf);
   REQUIRE(parser.is_used("--help"));

--- a/test/test_equals_form.cpp
+++ b/test/test_equals_form.cpp
@@ -6,8 +6,8 @@ import argparse;
 #include <doctest.hpp>
 
 #include <iostream>
-#include <vector>
 #include <string>
+#include <vector>
 
 using doctest::test_suite;
 

--- a/test/test_get.cpp
+++ b/test/test_get.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Implicit argument" * test_suite("ArgumentParser::get")) {
 
 TEST_CASE("Mismatched type for argument" * test_suite("ArgumentParser::get")) {
   argparse::ArgumentParser program("test");
-  program.add_argument("-s", "--stuff");  // as default type, a std::string
+  program.add_argument("-s", "--stuff"); // as default type, a std::string
   REQUIRE_NOTHROW(program.parse_args({"test", "-s", "321"}));
   REQUIRE_THROWS_AS(program.get<int>("--stuff"), std::bad_any_cast);
 }

--- a/test/test_help.cpp
+++ b/test/test_help.cpp
@@ -5,8 +5,8 @@ import argparse;
 #endif
 #include <doctest.hpp>
 
-#include <sstream>
 #include <optional>
+#include <sstream>
 
 using doctest::test_suite;
 
@@ -82,22 +82,19 @@ TEST_CASE("Users can replace default -h/--help" * test_suite("help")) {
 
 TEST_CASE("Multiline help message alignment") {
   // '#' is used at the beginning of each help message line to simplify testing.
-  // It is important to ensure that this character doesn't appear elsewhere in the test case.
-  // Default arguments (e.g., -h/--help, -v/--version) are not included in this test.
+  // It is important to ensure that this character doesn't appear elsewhere in
+  // the test case. Default arguments (e.g., -h/--help, -v/--version) are not
+  // included in this test.
   argparse::ArgumentParser program("program");
-  program.add_argument("INPUT1")
-      .help(
-        "#This is the first line of help message.\n"
-        "#And this is the second line of help message."
-      );
-  program.add_argument("program_input2")
-      .help("#There is only one line.");
+  program.add_argument("INPUT1").help(
+      "#This is the first line of help message.\n"
+      "#And this is the second line of help message.");
+  program.add_argument("program_input2").help("#There is only one line.");
   program.add_argument("-p", "--prog_input3")
       .help(
-R"(#Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          R"(#Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 #Sed ut perspiciatis unde omnis iste natus error sit voluptatem
-#accusantium doloremque laudantium, totam rem aperiam...)"
-      );
+#accusantium doloremque laudantium, totam rem aperiam...)");
   program.add_argument("--verbose").default_value(false).implicit_value(true);
 
   std::ostringstream stream;
@@ -107,7 +104,8 @@ R"(#Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   auto help_message_start = std::string::npos;
   std::string line;
   while (std::getline(iss, line)) {
-    // Find the position of '#', which indicates the start of the help message line
+    // Find the position of '#', which indicates the start of the help message
+    // line
     auto pos = line.find('#');
 
     if (pos == std::string::npos) {

--- a/test/test_parse_known_args.cpp
+++ b/test/test_parse_known_args.cpp
@@ -5,8 +5,8 @@ import argparse;
 #endif
 #include <doctest.hpp>
 
-#include <vector>
 #include <string>
+#include <vector>
 
 using doctest::test_suite;
 

--- a/test/test_repr.cpp
+++ b/test/test_repr.cpp
@@ -6,8 +6,8 @@ import argparse.details;
 #endif
 #include <doctest.hpp>
 
-#include <set>
 #include <list>
+#include <set>
 #include <sstream>
 
 using doctest::test_suite;

--- a/test/test_subparsers.cpp
+++ b/test/test_subparsers.cpp
@@ -6,8 +6,8 @@ import argparse;
 #include <doctest.hpp>
 
 #include <cmath>
-#include <vector>
 #include <string>
+#include <vector>
 
 using doctest::test_suite;
 
@@ -213,8 +213,8 @@ TEST_CASE("Check is_subcommand_used after parse" * test_suite("subparsers")) {
 
   argparse::ArgumentParser command_2("clean");
   command_2.add_argument("--fullclean")
-        .default_value(false)
-        .implicit_value(true);
+      .default_value(false)
+      .implicit_value(true);
 
   argparse::ArgumentParser program("test");
   program.add_subparser(command_1);


### PR DESCRIPTION
This PR adds in-built support for `.choices()` on arguments

```cpp
#include "argparse.hpp"

int main(int argc, char* argv[]) {
  argparse::ArgumentParser program("test");

  program.add_argument("input")
    .default_value("baz")
    .choices("foo", "bar", "baz");

  try {
    program.parse_args(argc, argv);
  }
  catch (const std::exception& err) {
    std::cerr << err.what() << std::endl;
    std::cerr << program;
    std::exit(1);
  }

  auto input = program.get("input");
  std::cout << input << std::endl;
}
```

```console
foo@bar:/home/dev/$ ./main fex
Invalid argument "fex" - allowed options: {foo, bar, baz}
```