### PR TITLE
Fix all samples building to "tests" binary

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -26,7 +26,6 @@ function(add_sample NAME)
   ADD_EXECUTABLE(ARGPARSE_SAMPLE_${NAME} ${NAME}.cpp)
   INCLUDE_DIRECTORIES("../include" ".")
   set_target_properties(ARGPARSE_SAMPLE_${NAME} PROPERTIES OUTPUT_NAME ${NAME})
-  set_target_properties(ARGPARSE_SAMPLE_${NAME} PROPERTIES OUTPUT_NAME tests)
   set_property(TARGET ARGPARSE_SAMPLE_${NAME} PROPERTY CXX_STANDARD 17)
 endfunction()
 


### PR DESCRIPTION
There was a line in samples/CMakeLists.txt which built all samples to the same binary name "tests", which made all the samples override each other while building.

```cmake
function(add_sample NAME)
  ADD_EXECUTABLE(ARGPARSE_SAMPLE_${NAME} ${NAME}.cpp)
  INCLUDE_DIRECTORIES("../include" ".")
  set_target_properties(ARGPARSE_SAMPLE_${NAME} PROPERTIES OUTPUT_NAME ${NAME})
  set_target_properties(ARGPARSE_SAMPLE_${NAME} PROPERTIES OUTPUT_NAME tests) # This line overrides the above line
  set_property(TARGET ARGPARSE_SAMPLE_${NAME} PROPERTY CXX_STANDARD 17)
endfunction()
```

Simply removing the line:

```cmake
function(add_sample NAME)
  ADD_EXECUTABLE(ARGPARSE_SAMPLE_${NAME} ${NAME}.cpp)
  INCLUDE_DIRECTORIES("../include" ".")
  set_target_properties(ARGPARSE_SAMPLE_${NAME} PROPERTIES OUTPUT_NAME ${NAME})
  set_property(TARGET ARGPARSE_SAMPLE_${NAME} PROPERTY CXX_STANDARD 17)
endfunction()
```
causes all of the binaries to properly build to their respective files.