### PR TITLE
Set argparse to not run tests or set up install if not top level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.12.4)
 
+if(NOT DEFINED PROJECT_NAME)
+  set(ARGPARSE_IS_TOP_LEVEL ON)
+else()
+  set(ARGPARSE_IS_TOP_LEVEL OFF)
+endif()
+
 project(argparse
         VERSION 2.9.0 
         DESCRIPTION "A single header argument parser for C++17"
@@ -9,6 +15,7 @@ project(argparse
 
 option(ARGPARSE_INSTALL "Include an install target" ON)
 option(ARGPARSE_BUILD_TESTS "Build tests" ON)
+option(ARGPARSE_BUILD_SAMPLES "Build samples" OFF)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
@@ -24,12 +31,12 @@ target_include_directories(argparse INTERFACE
 if(ARGPARSE_BUILD_SAMPLES)
   add_subdirectory(samples)
 endif()
-
-if(ARGPARSE_BUILD_TESTS)
+  
+if(ARGPARSE_BUILD_TESTS AND ARGPARSE_IS_TOP_LEVEL)
   add_subdirectory(test)
 endif()
-
-if(ARGPARSE_INSTALL)
+  
+if(ARGPARSE_INSTALL AND ARGPARSE_IS_TOP_LEVEL)
   install(TARGETS argparse EXPORT argparseConfig)
   install(EXPORT argparseConfig
           NAMESPACE argparse::

--- a/README.md
+++ b/README.md
@@ -1179,8 +1179,6 @@ PROJECT(myproject)
 
 # fetch latest argparse
 include(FetchContent)
-set(ARGPARSE_BUILD_TESTS OFF CACHE INTERNAL "Turn off building argparse tests")
-set(ARGPARSE_BUILD_SAMPLES OFF CACHE INTERNAL "Turn off building argparse samples")
 FetchContent_Declare(
     argparse
     GIT_REPOSITORY https://github.com/p-ranav/argparse.git


### PR DESCRIPTION
This pull request comes as a way to make sure users including argparse through FetchContent or through a direct add_subdirectory() call won't have argparse tests built or the argparse install commands configured by default.

Concerning not using the cmake provided [PROJECT_IS_TOP_LEVEL](https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html) variable, PROJECT_IS_TOP_LEVEL is not used because it has a required minimum cmake version of 3.21 while argparse uses a minimum cmake version of 3.12.4. 

This approach is largely based on the way [Catch2 handles this same condition (Lines 5-9)](https://github.com/catchorg/Catch2/blob/devel/CMakeLists.txt) in their CMakeLists.txt, as well as [this issue](https://github.com/catchorg/Catch2/issues/1373) which references to glitchy installs when setting install targets in a subdirectory CMake structure.

While the user will have to use FetchContent after their project call, this is also how the [official PROJECT_IS_TOP_LEVEL handles detecting subdirectory projects](https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html), so I don't see this as much of a concern. 

Also, I removed the manual setting of ARGPARSE_BUILD_TESTS and ARGPARSE_BUILD_SAMPLES from the FetchContent section of the README, as they are not necessary as ARGPARSE_BUILD_SAMPLES defaults to OFF and test building will now not be run if argparse is not the top level project.

ARGPARSE_BUILD_SAMPLES was also officially declared as an option, as well as initialized to OFF to maintain previous behavior. 