### PR TITLE
Closes #221

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,21 @@ foo@bar:/home/dev/$ ./main --first 1 --second 2
 Argument '--second VAR' not allowed with '--first VAR'
 ```
 
+The `add_mutually_exclusive_group()` function also accepts a `required` argument, to indicate that at least one of the mutually exclusive arguments is required:
+
+```cpp
+auto &group = program.add_mutually_exclusive_group(true);
+group.add_argument("--first");
+group.add_argument("--second");
+```
+
+with the following usage will yield an error:
+
+```console
+foo@bar:/home/dev/$ ./main
+One of the arguments '--first VAR' or '--second VAR' is required
+```
+
 ### Negative Numbers
 
 Optional arguments start with ```-```. Can ```argparse``` handle negative numbers? The answer is yes!

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
           *    [Deciding if the value was given by the user](#deciding-if-the-value-was-given-by-the-user)
           *    [Joining values of repeated optional arguments](#joining-values-of-repeated-optional-arguments)
           *    [Repeating an argument to increase a value](#repeating-an-argument-to-increase-a-value)
+          *    [Mutually Exclusive Group](#mutually-exclusive-group)
      *    [Negative Numbers](#negative-numbers)
      *    [Combining Positional and Optional Arguments](#combining-positional-and-optional-arguments)
      *    [Printing Help](#printing-help)
@@ -278,6 +279,23 @@ program.add_argument("-V", "--verbose")
 program.parse_args(argc, argv);    // Example: ./main -VVVV
 
 std::cout << "verbose level: " << verbosity << std::endl;    // verbose level: 4
+```
+
+#### Mutually Exclusive Group
+
+Create a mutually exclusive group using `program.add_mutually_exclusive_group(required = false)`. `argparse`` will make sure that only one of the arguments in the mutually exclusive group was present on the command line:
+
+```cpp
+auto &group = program.add_mutually_exclusive_group();
+group.add_argument("--first");
+group.add_argument("--second");
+```
+
+with the following usage will yield an error:
+
+```console
+foo@bar:/home/dev/$ ./main --first 1 --second 2
+Argument '--second VAR' not allowed with '--first VAR'
 ```
 
 ### Negative Numbers

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -481,10 +481,10 @@ std::string_view
 get_most_similar_string(const std::map<std::string_view, ValueType> &map,
                         const std::string_view input) {
   std::string_view most_similar{};
-  int min_distance = std::numeric_limits<int>::max();
+  std::size_t min_distance = std::numeric_limits<std::size_t>::max();
 
   for (const auto &entry : map) {
-    int distance = get_levenshtein_distance(entry.first, input);
+    std::size_t distance = get_levenshtein_distance(entry.first, input);
     if (distance < min_distance) {
       min_distance = distance;
       most_similar = entry.first;

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -46,7 +46,6 @@ SOFTWARE.
 #include <map>
 #include <numeric>
 #include <optional>
-#include <set>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -1429,7 +1428,7 @@ public:
         // argument_it = other.m_argument_map.find("name")
         auto first_name = arg->m_names[0];
         auto it = m_argument_map.find(first_name);
-        group.m_elements.insert(&(*it->second));
+        group.m_elements.push_back(&(*it->second));
       }
       m_mutually_exclusive_groups.push_back(std::move(group));
     }
@@ -1492,14 +1491,14 @@ public:
 
     template <typename... Targs> Argument &add_argument(Targs... f_args) {
       auto &argument = m_parent.add_argument(std::forward<Targs>(f_args)...);
-      m_elements.insert(&argument);
+      m_elements.push_back(&argument);
       return argument;
     }
 
   private:
     ArgumentParser &m_parent;
     bool m_required{false};
-    std::set<Argument *> m_elements{};
+    std::vector<Argument *> m_elements{};
   };
 
   MutuallyExclusiveGroup &add_mutually_exclusive_group(bool required = false) {

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -1588,6 +1588,25 @@ public:
                                    mutex_argument_it->get_usage_full() + "'");
         }
       }
+
+      if (!mutex_argument_used && group.m_required) {
+        // at least one argument from the group is
+        // required
+        std::string argument_names{};
+        std::size_t i = 0;
+        std::size_t size = group.m_elements.size();
+        for (Argument *arg : group.m_elements) {
+          if (i + 1 == size) {
+            // last
+            argument_names += "'" + arg->get_usage_full() + "' ";
+          } else {
+            argument_names += "'" + arg->get_usage_full() + "' or ";
+          }
+          i += 1;
+        }
+        throw std::runtime_error("One of the arguments " + argument_names +
+                                 "is required");
+      }
     }
   }
 

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -454,12 +454,13 @@ template <typename T> struct IsChoiceTypeSupported {
 };
 
 template <typename StringType>
-int get_levenshtein_distance(const StringType &s1, const StringType &s2) {
-  std::vector<std::vector<int>> dp(s1.size() + 1,
-                                   std::vector<int>(s2.size() + 1, 0));
+std::size_t get_levenshtein_distance(const StringType &s1,
+                                     const StringType &s2) {
+  std::vector<std::vector<std::size_t>> dp(
+      s1.size() + 1, std::vector<std::size_t>(s2.size() + 1, 0));
 
-  for (int i = 0; i <= s1.size(); ++i) {
-    for (int j = 0; j <= s2.size(); ++j) {
+  for (std::size_t i = 0; i <= s1.size(); ++i) {
+    for (std::size_t j = 0; j <= s2.size(); ++j) {
       if (i == 0) {
         dp[i][j] = j;
       } else if (j == 0) {
@@ -1420,9 +1421,9 @@ public:
       m_subparser_used.insert_or_assign(it->get().m_program_name, false);
     }
 
-    for (auto &g : other.m_mutually_exclusive_groups) {
+    for (const auto &g : other.m_mutually_exclusive_groups) {
       MutuallyExclusiveGroup group(*this, g.m_required);
-      for (auto &arg : g.m_elements) {
+      for (const auto &arg : g.m_elements) {
         // Find argument in argument map and add reference to it
         // in new group
         // argument_it = other.m_argument_map.find("name")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,7 @@ file(GLOB ARGPARSE_TEST_SOURCES
     test_invalid_arguments.cpp
     test_is_used.cpp
     test_issue_37.cpp
+    test_mutually_exclusive_group.cpp
     test_negative_numbers.cpp
     test_optional_arguments.cpp
     test_parent_parsers.cpp

--- a/test/test_mutually_exclusive_group.cpp
+++ b/test/test_mutually_exclusive_group.cpp
@@ -52,3 +52,20 @@ TEST_CASE("Create mutually exclusive group with 3 arguments" *
       "Argument '--third VAR' not allowed with '--first VAR'",
       std::runtime_error);
 }
+
+TEST_CASE("Create two mutually exclusive groups" * test_suite("mutex_args")) {
+  argparse::ArgumentParser program("test");
+
+  auto &group_1 = program.add_mutually_exclusive_group();
+  group_1.add_argument("--first");
+  group_1.add_argument("--second");
+  group_1.add_argument("--third");
+
+  auto &group_2 = program.add_mutually_exclusive_group();
+  group_2.add_argument("-a");
+  group_2.add_argument("-b");
+
+  REQUIRE_THROWS_WITH_AS(
+      program.parse_args({"test", "--first", "1", "-a", "2", "-b", "3"}),
+      "Argument '-b VAR' not allowed with '-a VAR'", std::runtime_error);
+}

--- a/test/test_mutually_exclusive_group.cpp
+++ b/test/test_mutually_exclusive_group.cpp
@@ -1,0 +1,21 @@
+#ifdef WITH_MODULE
+import argparse;
+#else
+#include <argparse/argparse.hpp>
+#endif
+#include <doctest.hpp>
+
+using doctest::test_suite;
+
+TEST_CASE("User-supplied argument" * test_suite("is_used")) {
+  argparse::ArgumentParser program("test");
+
+  auto &group = program.add_mutually_exclusive_group();
+  group.add_argument("--first");
+  group.add_argument("--second");
+
+  REQUIRE_THROWS_WITH_AS(
+      program.parse_args({"test", "--first", "1", "--second", "2"}),
+      "Argument '--first VAR' not allowed with '--second VAR'",
+      std::runtime_error);
+}

--- a/test/test_mutually_exclusive_group.cpp
+++ b/test/test_mutually_exclusive_group.cpp
@@ -22,6 +22,37 @@ TEST_CASE("Create mutually exclusive group with 2 arguments" *
 }
 
 TEST_CASE(
+    "Create mutually exclusive group with 2 arguments with required flag" *
+    test_suite("mutex_args")) {
+  argparse::ArgumentParser program("test");
+
+  auto &group = program.add_mutually_exclusive_group(true);
+  group.add_argument("--first");
+  group.add_argument("--second");
+
+  REQUIRE_THROWS_WITH_AS(
+      program.parse_args({"test"}),
+      "One of the arguments '--first VAR' or '--second VAR' is required",
+      std::runtime_error);
+}
+
+TEST_CASE(
+    "Create mutually exclusive group with 3 arguments with required flag" *
+    test_suite("mutex_args")) {
+  argparse::ArgumentParser program("test");
+
+  auto &group = program.add_mutually_exclusive_group(true);
+  group.add_argument("--first");
+  group.add_argument("--second");
+  group.add_argument("--third");
+
+  REQUIRE_THROWS_WITH_AS(program.parse_args({"test"}),
+                         "One of the arguments '--first VAR' or '--second VAR' "
+                         "or '--third VAR' is required",
+                         std::runtime_error);
+}
+
+TEST_CASE(
     "Create mutually exclusive group with 2 arguments, then copy the parser" *
     test_suite("mutex_args")) {
   argparse::ArgumentParser program("test");

--- a/test/test_mutually_exclusive_group.cpp
+++ b/test/test_mutually_exclusive_group.cpp
@@ -37,3 +37,18 @@ TEST_CASE(
       "Argument '--second VAR' not allowed with '--first VAR'",
       std::runtime_error);
 }
+
+TEST_CASE("Create mutually exclusive group with 3 arguments" *
+          test_suite("mutex_args")) {
+  argparse::ArgumentParser program("test");
+
+  auto &group = program.add_mutually_exclusive_group();
+  group.add_argument("--first");
+  group.add_argument("--second");
+  group.add_argument("--third");
+
+  REQUIRE_THROWS_WITH_AS(
+      program.parse_args({"test", "--first", "1", "--third", "2"}),
+      "Argument '--third VAR' not allowed with '--first VAR'",
+      std::runtime_error);
+}

--- a/test/test_mutually_exclusive_group.cpp
+++ b/test/test_mutually_exclusive_group.cpp
@@ -7,7 +7,8 @@ import argparse;
 
 using doctest::test_suite;
 
-TEST_CASE("User-supplied argument" * test_suite("is_used")) {
+TEST_CASE("Create mutually exclusive group with 2 arguments" *
+          test_suite("mutex_args")) {
   argparse::ArgumentParser program("test");
 
   auto &group = program.add_mutually_exclusive_group();
@@ -16,6 +17,23 @@ TEST_CASE("User-supplied argument" * test_suite("is_used")) {
 
   REQUIRE_THROWS_WITH_AS(
       program.parse_args({"test", "--first", "1", "--second", "2"}),
-      "Argument '--first VAR' not allowed with '--second VAR'",
+      "Argument '--second VAR' not allowed with '--first VAR'",
+      std::runtime_error);
+}
+
+TEST_CASE(
+    "Create mutually exclusive group with 2 arguments, then copy the parser" *
+    test_suite("mutex_args")) {
+  argparse::ArgumentParser program("test");
+
+  auto &group = program.add_mutually_exclusive_group();
+  group.add_argument("--first");
+  group.add_argument("--second");
+
+  auto program_copy(program);
+
+  REQUIRE_THROWS_WITH_AS(
+      program_copy.parse_args({"test", "--first", "1", "--second", "2"}),
+      "Argument '--second VAR' not allowed with '--first VAR'",
       std::runtime_error);
 }


### PR DESCRIPTION
Create a mutually exclusive group using `program.add_mutually_exclusive_group(required = false)`. `argparse`` will make sure that only one of the arguments in the mutually exclusive group was present on the command line:

```cpp
auto &group = program.add_mutually_exclusive_group();
group.add_argument("--first");
group.add_argument("--second");
```

with the following usage will yield an error:

```console
foo@bar:/home/dev/$ ./main --first 1 --second 2
Argument '--second VAR' not allowed with '--first VAR'
```

The `add_mutually_exclusive_group()` function also accepts a `required` argument, to indicate that at least one of the mutually exclusive arguments is required:

```cpp
auto &group = program.add_mutually_exclusive_group(true);
group.add_argument("--first");
group.add_argument("--second");
```

with the following usage will yield an error:

```console
foo@bar:/home/dev/$ ./main
One of the arguments '--first VAR' or '--second VAR' is required
```