### PR TITLE
Add fuzzing by way of ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/argparse
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/argparse

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,3 @@
+# ClusterFuzzLite set up
+
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,6 @@
+# Copy all fuzzer executables to $OUT/
+$CXX $CFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/argparse/.clusterfuzzlite/fuzz_argparse.cpp \
+  -o $OUT/fuzz_argparse \
+  -std=gnu++17 \
+  -I$SRC/argparse/include

--- a/.clusterfuzzlite/fuzz_argparse.cpp
+++ b/.clusterfuzzlite/fuzz_argparse.cpp
@@ -1,0 +1,34 @@
+#include <argparse/argparse.hpp>
+#include <fuzzer/FuzzedDataProvider.h>
+#include <string>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  FuzzedDataProvider fdp(data, size);
+
+  int args_to_generate = fdp.ConsumeIntegralInRange<int>(1, 10);
+  std::vector<std::string> fuzz_args;
+  for (int i = 0; i < args_to_generate; i++) {
+    fuzz_args.push_back(fdp.ConsumeRandomLengthString());
+  }
+
+  // Ensure none of the strings have sequences that cause exit:
+  // "-h", "--help", "-v", "--version"
+  for (int i = 0; i < args_to_generate; i++) {
+    if (fuzz_args[i].find("-h") != std::string::npos ||
+        fuzz_args[i].find("-v") != std::string::npos) {
+      return 0;
+    }
+  }
+
+  argparse::ArgumentParser program("test");
+  program.add_argument("--config");
+  program.add_argument("--test");
+  program.add_argument("--fuzzval");
+  program.add_argument("--param");
+  try {
+    program.parse_args(fuzz_args);
+  } catch (...) {
+  }
+
+  return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c++

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 120
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

I added a fuzzer that targets creates a random (fuzzer-seeded) vector of strings, simulating arbitrary arguments and then use a fixed parser to parse this. Currently the timeout of CFLite is set to 120 seconds. CFLite will flag if the fuzzer finds  any issues in the code introduced by a PR.