### PR TITLE
Make clang -fsanitize=unsigned-integer-overflow happy

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -1734,12 +1734,12 @@ public:
    * @throws std::logic_error in case of an invalid argument name
    */
   Argument &operator[](std::string_view arg_name) const {
-    auto it = m_argument_map.find(arg_name);
+    std::string name(arg_name);
+    auto it = m_argument_map.find(name);
     if (it != m_argument_map.end()) {
       return *(it->second);
     }
     if (!is_valid_prefix_char(arg_name.front())) {
-      std::string name(arg_name);
       const auto legal_prefix_char = get_any_valid_prefix_char();
       const auto prefix = std::string(1, legal_prefix_char);
 
@@ -2172,7 +2172,7 @@ private:
   bool m_is_parsed = false;
   std::list<Argument> m_positional_arguments;
   std::list<Argument> m_optional_arguments;
-  std::map<std::string_view, argument_it> m_argument_map;
+  std::map<std::string, argument_it> m_argument_map;
   std::string m_parser_path;
   std::list<std::reference_wrapper<ArgumentParser>> m_subparsers;
   std::map<std::string_view, argument_parser_it> m_subparser_map;

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -545,10 +545,9 @@ std::size_t get_levenshtein_distance(const StringType &s1,
 }
 
 template <typename ValueType>
-std::string_view
-get_most_similar_string(const std::map<std::string_view, ValueType> &map,
-                        const std::string_view input) {
-  std::string_view most_similar{};
+std::string get_most_similar_string(const std::map<std::string, ValueType> &map,
+                                    const std::string &input) {
+  std::string most_similar{};
   std::size_t min_distance = std::numeric_limits<std::size_t>::max();
 
   for (const auto &entry : map) {
@@ -1586,11 +1585,12 @@ public:
     if constexpr (std::is_same_v<T, Argument>) {
       return (*this)[name];
     } else {
-      auto subparser_it = m_subparser_map.find(name);
+      std::string str_name(name);
+      auto subparser_it = m_subparser_map.find(str_name);
       if (subparser_it != m_subparser_map.end()) {
         return subparser_it->second->get();
       }
-      throw std::logic_error("No such subparser: " + std::string(name));
+      throw std::logic_error("No such subparser: " + str_name);
     }
   }
 
@@ -1720,7 +1720,7 @@ public:
   /* Getter that returns true if a subcommand is used.
    */
   auto is_subcommand_used(std::string_view subcommand_name) const {
-    return m_subparser_used.at(subcommand_name);
+    return m_subparser_used.at(std::string(subcommand_name));
   }
 
   /* Getter that returns true if a subcommand is used.
@@ -1972,10 +1972,8 @@ private:
       if (Argument::is_positional(current_argument, m_prefix_chars)) {
         if (positional_argument_it == std::end(m_positional_arguments)) {
 
-          std::string_view maybe_command = current_argument;
-
           // Check sub-parsers
-          auto subparser_it = m_subparser_map.find(maybe_command);
+          auto subparser_it = m_subparser_map.find(current_argument);
           if (subparser_it != m_subparser_map.end()) {
 
             // build list of remaining args
@@ -1984,7 +1982,7 @@ private:
 
             // invoke subparser
             m_is_parsed = true;
-            m_subparser_used[maybe_command] = true;
+            m_subparser_used[current_argument] = true;
             return subparser_it->second->get().parse_args(
                 unprocessed_arguments);
           }
@@ -2075,10 +2073,8 @@ private:
       if (Argument::is_positional(current_argument, m_prefix_chars)) {
         if (positional_argument_it == std::end(m_positional_arguments)) {
 
-          std::string_view maybe_command = current_argument;
-
           // Check sub-parsers
-          auto subparser_it = m_subparser_map.find(maybe_command);
+          auto subparser_it = m_subparser_map.find(current_argument);
           if (subparser_it != m_subparser_map.end()) {
 
             // build list of remaining args
@@ -2087,7 +2083,7 @@ private:
 
             // invoke subparser
             m_is_parsed = true;
-            m_subparser_used[maybe_command] = true;
+            m_subparser_used[current_argument] = true;
             return subparser_it->second->get().parse_known_args_internal(
                 unprocessed_arguments);
           }
@@ -2175,8 +2171,8 @@ private:
   std::map<std::string, argument_it> m_argument_map;
   std::string m_parser_path;
   std::list<std::reference_wrapper<ArgumentParser>> m_subparsers;
-  std::map<std::string_view, argument_parser_it> m_subparser_map;
-  std::map<std::string_view, bool> m_subparser_used;
+  std::map<std::string, argument_parser_it> m_subparser_map;
+  std::map<std::string, bool> m_subparser_used;
   std::vector<MutuallyExclusiveGroup> m_mutually_exclusive_groups;
   bool m_suppress = false;
 };


### PR DESCRIPTION
I'm integrating this fantastic library into a larger project (https://gdal.org) that has a CI configuration building with clang's  ``-fsanitize=unsigned-integer-overflow`` mode, and it currently halts in a few places of argparse. This is apparently due to the std::map<> methods using unsigned integer overflow when they key is a std::string_view, at least with clang 10 on Ubuntu 20.04. Unsigned integer overflow is well defined behavior in C/C++, but I tend to think it is preferable to avoid it to be able to detect real bugs where the overflow is not desired. With those changes, argparse unit test now run fine with ``-fsanitize=unsigned-integer-overflow``
I also find it quite fragile to use a std::string_view as the key of a map. This assumes that the key has a lifetime greater or equal to the instance of argparse (I actually got bitten by this in a customization of argparse, where I didn't realize I couldn't use an ephemeral string)