### PR TITLE
If given, show allowed choices in help message.

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -1186,6 +1186,19 @@ public:
         stream << " ";
       }
       stream << "[may be repeated]";
+      add_space = true;
+    }
+    if (argument.m_choices.has_value()) {
+      if (add_space) {
+        stream << " ";
+      }
+      const auto &choices = argument.m_choices.value();
+      std::string choices_as_csv =
+          std::accumulate(choices.begin(), choices.end(), std::string(),
+                          [](const std::string &a, const std::string &b) {
+                            return a + (a.empty() ? "" : ", ") + b;
+                          });
+      stream << "[allowed: " << choices_as_csv << "]";
     }
     stream << "\n";
     return stream;

--- a/test/test_choices.cpp
+++ b/test/test_choices.cpp
@@ -155,3 +155,16 @@ TEST_CASE("Parse multiple arguments that are not in fixed number of allowed "
       "Invalid argument \"6\" - allowed options: {1, 2, 3, 4, 5}",
       std::runtime_error);
 }
+
+TEST_CASE("Show allowed choices in help test") {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--color").choices("red", "green", "blue");
+  program.add_argument("--index").choices(1, 2, 3);
+
+  auto help_output = program.help().str();
+
+  REQUIRE(help_output.find(std::string{"[allowed: red, green, blue]"}) !=
+          std::string::npos);
+  REQUIRE(help_output.find(std::string{"[allowed: 1, 2, 3]"}) !=
+          std::string::npos);
+}


### PR DESCRIPTION
Previously, the only way for the user to get a list of allowed choices was to run the command with an incorrect choice. This commit adds the list of allowed choices to the help message.