### PR TITLE
Convert default value using action()

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -1485,6 +1485,14 @@ private:
       }
     }
     if (m_default_value.has_value()) {
+      if (m_default_value_str.has_value()) {
+        if (!m_implicit_value.has_value()) {
+          if (std::holds_alternative<valued_action>(m_action)) {
+            return std::any_cast<T>(
+                std::get<valued_action>(m_action)(*m_default_value_str));
+          }
+        }
+      }
       return std::any_cast<T>(m_default_value);
     }
     if constexpr (details::IsContainer<T>) {

--- a/test/test_default_value.cpp
+++ b/test/test_default_value.cpp
@@ -81,3 +81,39 @@ TEST_CASE("Position of the argument with default value") {
     REQUIRE(program.get("-s") == std::string("./src"));
   }
 }
+
+TEST_CASE("Custom data type with default value") {
+  enum class CustomType { Value1, Value2, INVALID };
+
+  auto convert_custom_type = [](const std::string &input) -> CustomType {
+    if (input == "value1") {
+      return CustomType::Value1;
+    }
+    if (input == "value2") {
+      return CustomType::Value2;
+    }
+    return CustomType::INVALID;
+  };
+
+  argparse::ArgumentParser program("test");
+  program.add_argument("--custom1")
+      .default_value("value1")
+      .action(convert_custom_type);
+  program.add_argument("--custom2")
+      .default_value("value2")
+      .action(convert_custom_type);
+  program.add_argument("--custom3")
+      .default_value("value3")
+      .action(convert_custom_type);
+  program.add_argument("--custom4")
+      .default_value("value1")
+      .action(convert_custom_type);
+
+  // custom1-3 as their default values, custom4 with given value
+  REQUIRE_NOTHROW(program.parse_args({"test", "--custom4", "value2"}));
+
+  REQUIRE(program.get<CustomType>("custom1") == CustomType::Value1);
+  REQUIRE(program.get<CustomType>("custom2") == CustomType::Value2);
+  REQUIRE(program.get<CustomType>("custom3") == CustomType::INVALID);
+  REQUIRE(program.get<CustomType>("custom4") == CustomType::Value2);
+}


### PR DESCRIPTION
If using an `action()` to convert the input values into custom data types, the default value poses an issue when using `choices()`. `m_choices` is a `vector<string>` so the default value also has to be comparable to a string, for the given value to be accepted.

This commit solves this by patching `get()` to convert the default value using the same `action()`.

It is not the cleanest solution (default value has to be given as string instead of the target type), but the alternative I came up with would have changed `m_choices` to a typed vector which would have had wider consequences so I didn't pursue that path.