### PR TITLE
add Bazel support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,8 @@
+build --enable_platform_specific_config
+
+build:linux --cxxopt=-std=c++17
+
+build:windows --copt=/utf-8
+build:windows --copt=/Zc:preprocessor
+build:windows --cxxopt=/std:c++17
+build:windows --cxxopt=/Zc:__cplusplus

--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,7 @@ analysis-cppcheck-build-dir
 ideas
 
 desktop.iniimages/
+
+# Ignore all bazel-* symlinks. There is no full list since this can change
+# based on the name of the directory bazel is cloned into.
+/bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,6 @@
+cc_library(
+    name = "argparse",
+    hdrs = ["include/argparse/argparse.hpp"],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/README.md
+++ b/README.md
@@ -1391,6 +1391,19 @@ add_executable(myproject main.cpp)
 target_link_libraries(myproject argparse)
 ```
 
+## Bazel Integration
+
+Add an `http_archive` in WORKSPACE.bazel, for example
+
+```starlark
+http_archive(
+    name = "argparse",
+    sha256 = "674e724c2702f0bfef1619161815257a407e1babce30d908327729fba6ce4124",
+    strip_prefix = "argparse-3.0",
+    url = "https://github.com/p-ranav/argparse/archive/refs/tags/v3.0.zip",
+)
+```
+
 ## Building, Installing, and Testing
 
 ```bash

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,1 @@
+workspace(name="argparse")

--- a/samples/BUILD.bazel
+++ b/samples/BUILD.bazel
@@ -1,0 +1,31 @@
+load(":add_sample.bzl", "add_sample")
+
+add_sample(name = "positional_argument")
+
+add_sample(name = "optional_flag_argument")
+
+add_sample(name = "required_optional_argument")
+
+add_sample(name = "is_used")
+
+add_sample(name = "joining_repeated_optional_arguments")
+
+add_sample(name = "repeating_argument_to_increase_value")
+
+add_sample(name = "negative_numbers")
+
+add_sample(name = "description_epilog_metavar")
+
+add_sample(name = "list_of_arguments")
+
+add_sample(name = "compound_arguments")
+
+add_sample(name = "gathering_remaining_arguments")
+
+add_sample(name = "subcommands")
+
+add_sample(name = "parse_known_args")
+
+add_sample(name = "custom_prefix_characters")
+
+add_sample(name = "custom_assignment_characters")

--- a/samples/add_sample.bzl
+++ b/samples/add_sample.bzl
@@ -1,0 +1,6 @@
+def add_sample(name):
+    native.cc_binary(
+        name = name,
+        srcs = ["{}.cpp".format(name)],
+        deps = ["//:argparse"],
+    )

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,0 +1,23 @@
+cc_library(
+    name = "doctest",
+    srcs = [
+        "main.cpp",
+    ],
+    hdrs = ["doctest.hpp"],
+    includes = ["."],
+    local_defines = [
+        "DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN",
+    ],
+)
+
+cc_test(
+    name = "test",
+    srcs = glob(["test_*.cpp"]) + [
+        "test_utility.hpp",
+    ],
+    includes = ["."],
+    deps = [
+        ":doctest",
+        "//:argparse",
+    ],
+)


### PR DESCRIPTION
I noticed there was a PR to try to add bazel support. My PR doesn't contain non-Bazel-oriented commits and it has been tested on ArchLinux and Windows 11.