### PR TITLE
do_from_chars(): initialize variable to fix Coverity Scan warning

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -238,7 +238,7 @@ constexpr auto consume_hex_prefix(std::string_view s)
 
 template <class T, auto Param>
 inline auto do_from_chars(std::string_view s) -> T {
-  T x;
+  T x{0};
   auto [first, last] = pointer_range(s);
   auto [ptr, ec] = std::from_chars(first, last, x, Param);
   if (ec == std::errc()) {


### PR DESCRIPTION
The argparse.hpp copy inside GDAL has caused Coverity Scan to emit a (false-positive) warning about x not being initialized.

```
________________________________________________________________________________________________________
*** CID 1544814:  Uninitialized variables  (UNINIT)
/gdal/apps/argparse/argparse.hpp: 257 in gdal_argparse::details::do_from_chars<unsigned char, (int)10>(std::basic_string_view<char, std::char_traits<char>>)()
251       if (ec == std::errc::invalid_argument) {
252         throw std::invalid_argument{"pattern '" + std::string(s) + "' not found"};
253       }
254       if (ec == std::errc::result_out_of_range) {
255         throw std::range_error{"'" + std::string(s) + "' not representable"};
256       }
>>>     CID 1544814:  Uninitialized variables  (UNINIT)
>>>     Using uninitialized value "x".
```

Let's initialize it to 0 to make the analyzer happy