### PR TITLE
Module improvement.

### DIFF
--- a/module/argparse.cppm
+++ b/module/argparse.cppm
@@ -42,7 +42,10 @@ import std;
 import std.compat;
 
 extern "C++" {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winclude-angled-in-module-purview"
 #include <argparse/argparse.hpp>
+#pragma clang diagnostic pop
 }
 #endif
 


### PR DESCRIPTION
This PR does:

- Suppress `include-angled-in-module-purview` warning. Export extern "C++" style is valid in Clang (https://clang.llvm.org/docs/StandardCPlusPlusModules.html#export-extern-c-style), but warning is emitted. This commit disables it.