### PR TITLE
parse_args(): work around GCC 12 warning bug.

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -1831,9 +1831,9 @@ public:
         for (Argument *arg : group.m_elements) {
           if (i + 1 == size) {
             // last
-            argument_names += "'" + arg->get_usage_full() + "' ";
+            argument_names += std::string("'") + arg->get_usage_full() + std::string("' ");
           } else {
-            argument_names += "'" + arg->get_usage_full() + "' or ";
+            argument_names += std::string("'") + arg->get_usage_full() + std::string("' or ");
           }
           i += 1;
         }


### PR DESCRIPTION
This bug [1] causes GCC to emit a wrong warning when adding a short string literal to a std::string. Wrapping the literal in a std::string doesn't have a large impact and avoids the warning.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329

---

Fixes #358 