### PR TITLE
Add argument name after 'Too few arguments' error

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -997,7 +997,8 @@ public:
             std::bind(is_optional, std::placeholders::_1, m_prefix_chars));
         dist = static_cast<std::size_t>(std::distance(start, end));
         if (dist < num_args_min) {
-          throw std::runtime_error("Too few arguments");
+          throw std::runtime_error("Too few arguments for '" +
+                                   std::string(m_used_name) + "'.");
         }
       }
 

--- a/test/test_parse_args.cpp
+++ b/test/test_parse_args.cpp
@@ -17,6 +17,15 @@ TEST_CASE("Missing argument" * test_suite("parse_args")) {
                          std::runtime_error);
 }
 
+TEST_CASE("Missing argument, not last" * test_suite("parse_args")) {
+  argparse::ArgumentParser program("test");
+  program.add_argument("--config").nargs(1);
+  program.add_argument("--foo");
+  REQUIRE_THROWS_WITH_AS(program.parse_args({"test", "--config", "--foo"}),
+                         "Too few arguments for '--config'.",
+                         std::runtime_error);
+}
+
 TEST_CASE("Parse a string argument with value" * test_suite("parse_args")) {
   argparse::ArgumentParser program("test");
   program.add_argument("--config");


### PR DESCRIPTION
If a non-positional argument doesn't get the number of required values, a generic "Too few arguments" error is generated, without its name, when it is not the last argument (but if it is the last argument, we get its name)