### PR TITLE
Accept integer literals in store_into

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -702,7 +702,14 @@ public:
   template <typename T, typename std::enable_if<std::is_integral<T>::value>::type * = nullptr>
   auto &store_into(T &var) {
     if (m_default_value.has_value()) {
-      var = std::any_cast<T>(m_default_value);
+      try
+      {
+        var = std::any_cast<T>(m_default_value);
+      }
+      catch (...)
+      {
+        var = static_cast<T>(std::any_cast<int>(m_default_value));
+      }
     }
     action([&var](const auto &s) {
       var = details::parse_number<T, details::radix_10>()(s);
@@ -712,7 +719,14 @@ public:
 
   auto &store_into(double &var) {
     if (m_default_value.has_value()) {
-      var = std::any_cast<double>(m_default_value);
+      try
+      {
+        var = std::any_cast<double>(m_default_value);
+      }
+      catch (...)
+      {
+        var = std::any_cast<int>(m_default_value);
+      }
     }
     action([&var](const auto &s) {
       var = details::parse_number<double, details::chars_format::general>()(s);

--- a/test/test_store_into.cpp
+++ b/test/test_store_into.cpp
@@ -286,3 +286,11 @@ TEST_CASE("Test store_into(set of string), default value, multi valued, specifie
   }
 }
 
+TEST_CASE("Test store_into other types with integer default" * test_suite("store_into"))
+{
+  argparse::ArgumentParser program("test");
+  double res = -1;
+  REQUIRE_NOTHROW(program.add_argument("--double-opt").default_value(3).store_into(res));
+  uint8_t u = 25;
+  REQUIRE_NOTHROW(program.add_argument("--uint8_t-opt").default_value(3).store_into(u));
+}


### PR DESCRIPTION
Allow integer literals as default values in store_into for numeric types.