### PR TITLE
Allow to install when argparse is a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,8 @@ project(argparse
         LANGUAGES CXX
 )
 
-option(ARGPARSE_INSTALL "Include an install target" ON)
-option(ARGPARSE_BUILD_TESTS "Build tests" ON)
+option(ARGPARSE_INSTALL "Include an install target" ${ARGPARSE_IS_TOP_LEVEL})
+option(ARGPARSE_BUILD_TESTS "Build tests" ${ARGPARSE_IS_TOP_LEVEL})
 option(ARGPARSE_BUILD_SAMPLES "Build samples" OFF)
 
 include(GNUInstallDirs)
@@ -32,11 +32,11 @@ if(ARGPARSE_BUILD_SAMPLES)
   add_subdirectory(samples)
 endif()
   
-if(ARGPARSE_BUILD_TESTS AND ARGPARSE_IS_TOP_LEVEL)
+if(ARGPARSE_BUILD_TESTS)
   add_subdirectory(test)
 endif()
   
-if(ARGPARSE_INSTALL AND ARGPARSE_IS_TOP_LEVEL)
+if(ARGPARSE_INSTALL)
   install(TARGETS argparse EXPORT argparseConfig)
   install(EXPORT argparseConfig
           NAMESPACE argparse::


### PR DESCRIPTION
Changed CMakeLists.txt so that users can install argparse when argparse is a subproject (e.g. CMake FetchContent).