### PR TITLE
Fix a typo in the readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ The process of gathering remaining arguments plays nicely with optional argument
 ```cpp
 argparse::ArgumentParser program("compiler");
 
-program.add_arguments("-o")
+program.add_argument("-o")
   .default_value(std::string("a.out"));
 
 program.add_argument("files")


### PR DESCRIPTION
Fix a typo in the readme documentation example. 
Wrote `.add_arguments` instead of `.add_argument`, which is invalid. 