### PR TITLE
Fix parsing 0 parameters when using choices

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -1009,7 +1009,7 @@ public:
     }
 
     const auto num_args_max =
-        (m_choices.has_value()) ? passed_options : m_num_args_range.get_max();
+        (passed_options > 0) ? passed_options : m_num_args_range.get_max();
     const auto num_args_min = m_num_args_range.get_min();
     std::size_t dist = 0;
     if (num_args_max == 0) {


### PR DESCRIPTION
Before, when an option used choices, but the user passed no argument, instead of giving the too-few-arguments given error, a bad any cast exception was thrown. This is now fixed by not accidentally changing `num_args_max` to 0 before the number-of-arguments check.

E.g. running `./program --color` (i.e. no arguments)
```
    parser.add_argument("--color")
        .help("configure the use of colors in output")
        .choices("auto", "always", "never");
```
caused the (unhelpful) exception
```
libc++abi: terminating due to uncaught exception of type std::bad_any_cast: bad any cast
```
at the line
```
auto fn = parser.present("--color");
```
With the change, the same invocation gives us the much more helpful
```
Too few arguments for '--color'.
```